### PR TITLE
perf(backend): reuse ReverseProxy, add shared transport, cache SSR th…

### DIFF
--- a/internal/app/middleware/ssr_proxy.go
+++ b/internal/app/middleware/ssr_proxy.go
@@ -11,6 +11,8 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"sync"
+	"time"
 
 	frontend_runtime "github.com/anzhiyu-c/anheyu-app/internal/frontend"
 	"github.com/anzhiyu-c/anheyu-app/pkg/ssr"
@@ -26,15 +28,131 @@ type CurrentSSRThemeChecker func() (themeName string, shouldProxy bool)
 // ssrThemeChecker 全局的 SSR 主题检查器
 var ssrThemeChecker CurrentSSRThemeChecker
 
+// ssrThemeCheckCache caches the result of the SSR theme checker with a TTL
+// to avoid hitting the database on every request.
+type ssrThemeCheckCache struct {
+	mu         sync.RWMutex
+	themeName  string
+	shouldProxy bool
+	expiresAt   time.Time
+}
+
+var ssrCheckCache = &ssrThemeCheckCache{}
+
+const ssrCheckCacheTTL = 5 * time.Second
+
+func (c *ssrThemeCheckCache) get() (themeName string, shouldProxy bool, ok bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if time.Now().Before(c.expiresAt) {
+		return c.themeName, c.shouldProxy, true
+	}
+	return "", false, false
+}
+
+func (c *ssrThemeCheckCache) set(themeName string, shouldProxy bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.themeName = themeName
+	c.shouldProxy = shouldProxy
+	c.expiresAt = time.Now().Add(ssrCheckCacheTTL)
+}
+
+// cachedSSRThemeCheck returns the cached SSR theme check result,
+// falling back to the database-backed checker on cache miss.
+func cachedSSRThemeCheck() (themeName string, shouldProxy bool) {
+	if themeName, shouldProxy, ok := ssrCheckCache.get(); ok {
+		return themeName, shouldProxy
+	}
+	themeName, shouldProxy = ssrThemeChecker()
+	ssrCheckCache.set(themeName, shouldProxy)
+	return
+}
+
 // SetSSRThemeChecker 设置 SSR 主题检查器
 // 应在应用启动时调用，传入检查数据库状态的回调函数
 func SetSSRThemeChecker(checker CurrentSSRThemeChecker) {
 	ssrThemeChecker = checker
 }
 
+// ssrProxyState holds the reusable reverse proxy and tracks the current SSR target.
+type ssrProxyState struct {
+	mu        sync.RWMutex
+	proxy     *httputil.ReverseProxy
+	targetURL string // current "http://localhost:PORT"
+}
+
+// newSSRProxyState creates the proxy state with a nil proxy (lazy init on first use).
+func newSSRProxyState() *ssrProxyState {
+	return &ssrProxyState{}
+}
+
+// getProxy returns the shared reverse proxy for the given target URL.
+// It reuses the existing proxy if the target hasn't changed; otherwise creates a new one.
+func (ps *ssrProxyState) getProxy(targetURL string, themeName string, port int) *httputil.ReverseProxy {
+	ps.mu.RLock()
+	same := ps.targetURL == targetURL && ps.proxy != nil
+	ps.mu.RUnlock()
+	if same {
+		return ps.proxy
+	}
+
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if ps.targetURL == targetURL && ps.proxy != nil {
+		return ps.proxy
+	}
+
+	target, err := url.Parse(targetURL)
+	if err != nil {
+		log.Printf("[SSR 代理] 解析目标 URL 失败: %v", err)
+		return nil
+	}
+
+	ps.proxy = &httputil.ReverseProxy{
+		Transport: frontend_runtime.SharedTransport,
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.Host = target.Host
+			req.Header.Set("X-Forwarded-Host", req.Header.Get("X-Forwarded-Host"))
+			req.Header.Set("X-Real-IP", req.Header.Get("X-Real-IP"))
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
+			log.Printf("[SSR 代理] 错误: %v (主题: %s, 端口: %d)", err, themeName, port)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>SSR 主题暂时不可用</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; text-align: center; padding: 50px; }
+        h1 { color: #333; }
+        p { color: #666; }
+    </style>
+</head>
+<body>
+    <h1>SSR 主题暂时不可用</h1>
+    <p>主题 "%s" 正在启动中或遇到问题，请稍后重试。</p>
+    <p><a href="/admin">前往后台管理</a></p>
+</body>
+</html>`, themeName)))
+		},
+	}
+
+	ps.targetURL = targetURL
+	return ps.proxy
+}
+
 // SSRProxyMiddleware 创建 SSR 主题反向代理中间件
 // 当有 SSR 主题运行时，将前台请求（非 API、非后台）代理到 SSR 主题
 func SSRProxyMiddleware(ssrManager *ssr.Manager) gin.HandlerFunc {
+	// Create reusable proxy state once at middleware creation time
+	proxyState := newSSRProxyState()
+
 	return func(c *gin.Context) {
 		// 如果没有 SSR 管理器，直接跳过
 		if ssrManager == nil {
@@ -57,10 +175,10 @@ func SSRProxyMiddleware(ssrManager *ssr.Manager) gin.HandlerFunc {
 			return
 		}
 
-		// 优先使用 checker 检查数据库状态（如果已设置）
+		// 优先使用 checker 检查数据库状态（如果已设置），使用缓存避免每次请求查库
 		var runningTheme *ssr.ThemeInfo
 		if ssrThemeChecker != nil {
-			themeName, shouldProxy := ssrThemeChecker()
+			themeName, shouldProxy := cachedSSRThemeCheck()
 			if !shouldProxy {
 				// 数据库说当前不应该使用 SSR 主题，直接跳过代理
 				c.Next()
@@ -84,51 +202,17 @@ func SSRProxyMiddleware(ssrManager *ssr.Manager) gin.HandlerFunc {
 			return
 		}
 
-		// 创建反向代理目标
+		// 创建或复用反向代理
 		targetURL := fmt.Sprintf("http://localhost:%d", runningTheme.Port)
-		target, err := url.Parse(targetURL)
-		if err != nil {
-			log.Printf("[SSR 代理] 解析目标 URL 失败: %v", err)
+		proxy := proxyState.getProxy(targetURL, runningTheme.Name, runningTheme.Port)
+		if proxy == nil {
 			c.Next()
 			return
 		}
 
-		// 创建反向代理
-		proxy := httputil.NewSingleHostReverseProxy(target)
-
-		// 自定义 Director 保留原始请求信息
-		originalDirector := proxy.Director
-		proxy.Director = func(req *http.Request) {
-			originalDirector(req)
-			// 保留原始 Host 头（某些 SSR 框架可能需要）
-			req.Host = req.URL.Host
-			// 添加代理标识头
-			req.Header.Set("X-Forwarded-Host", c.Request.Host)
-			req.Header.Set("X-Real-IP", c.ClientIP())
-		}
-
-		// 错误处理：当 SSR 进程不可用时返回友好错误
-		proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
-			log.Printf("[SSR 代理] 错误: %v (主题: %s, 端口: %d)", err, runningTheme.Name, runningTheme.Port)
-			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte(fmt.Sprintf(`<!DOCTYPE html>
-<html>
-<head>
-    <meta charset="utf-8">
-    <title>SSR 主题暂时不可用</title>
-    <style>
-        body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; text-align: center; padding: 50px; }
-        h1 { color: #333; }
-        p { color: #666; }
-    </style>
-</head>
-<body>
-    <h1>SSR 主题暂时不可用</h1>
-    <p>主题 "%s" 正在启动中或遇到问题，请稍后重试。</p>
-    <p><a href="/admin">前往后台管理</a></p>
-</body>
-</html>`, runningTheme.Name)))
-		}
+		// Set per-request headers on the incoming request
+		c.Request.Header.Set("X-Forwarded-Host", c.Request.Host)
+		c.Request.Header.Set("X-Real-IP", c.ClientIP())
 
 		// 代理请求
 		proxy.ServeHTTP(c.Writer, c.Request)

--- a/internal/frontend/page_cache.go
+++ b/internal/frontend/page_cache.go
@@ -1,0 +1,223 @@
+// Package frontend provides a lightweight in-memory page cache for proxied
+// Next.js responses. It eliminates the Next.js SSR + DB query round-trip for
+// frequently-accessed public pages, reducing TTFB to sub-millisecond levels.
+package frontend
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// cacheEntry holds a cached HTTP response.
+type cacheEntry struct {
+	body       []byte
+	header     http.Header
+	statusCode int
+	expiresAt  time.Time
+}
+
+// pageCache is a simple in-memory TTL cache for proxied page responses.
+// Only public GET requests to cacheable paths are stored.
+type pageCache struct {
+	mu    sync.RWMutex
+	items map[string]*cacheEntry
+}
+
+var sharedPageCache = &pageCache{
+	items: make(map[string]*cacheEntry, 256),
+}
+
+// cacheTTL returns the TTL for a given request path.
+// Content pages get 15s, listing pages get 30s, static-like pages get 60s.
+func cacheTTL(path string) time.Duration {
+	switch {
+	case path == "/":
+		return 15 * time.Second
+	case strings.HasPrefix(path, "/posts/"):
+		return 15 * time.Second
+	case strings.HasPrefix(path, "/categories"):
+		return 30 * time.Second
+	case strings.HasPrefix(path, "/tags"):
+		return 30 * time.Second
+	case strings.HasPrefix(path, "/archives"):
+		return 30 * time.Second
+	case strings.HasPrefix(path, "/about"):
+		return 60 * time.Second
+	case strings.HasPrefix(path, "/link"):
+		return 30 * time.Second
+	case strings.HasPrefix(path, "/album"):
+		return 30 * time.Second
+	case strings.HasPrefix(path, "/page"):
+		return 60 * time.Second
+	default:
+		return 10 * time.Second
+	}
+}
+
+// isCacheablePath returns true if the path is eligible for response caching.
+// Admin, auth, and user-specific pages are never cached.
+func isCacheablePath(path string) bool {
+	skipPrefixes := []string{
+		"/admin", "/login", "/user-center", "/api/",
+		"/_next/", "/f/", "/needcache/", "/static/",
+	}
+	for _, prefix := range skipPrefixes {
+		if strings.HasPrefix(path, prefix) {
+			return false
+		}
+	}
+	return true
+}
+
+// hasAuthCookie checks if the request contains authentication tokens.
+func hasAuthCookie(r *http.Request) bool {
+	for _, c := range r.Cookies() {
+		if c.Name == "access_token" || c.Name == "refresh_token" {
+			return true
+		}
+	}
+	return r.Header.Get("Authorization") != ""
+}
+
+// get retrieves a cached response. Returns nil if not found or expired.
+func (pc *pageCache) get(key string) *cacheEntry {
+	pc.mu.RLock()
+	entry, ok := pc.items[key]
+	pc.mu.RUnlock()
+
+	if !ok {
+		return nil
+	}
+	if time.Now().After(entry.expiresAt) {
+		pc.mu.Lock()
+		delete(pc.items, key)
+		pc.mu.Unlock()
+		return nil
+	}
+	return entry
+}
+
+// set stores a response in the cache with a path-appropriate TTL.
+func (pc *pageCache) set(key string, body []byte, header http.Header, statusCode int) {
+	ttl := cacheTTL(key)
+	if ttl <= 0 {
+		return
+	}
+	// Clone the header to avoid retaining references to the original request
+	clonedHeader := header.Clone()
+
+	entry := &cacheEntry{
+		body:       make([]byte, len(body)),
+		header:     clonedHeader,
+		statusCode: statusCode,
+		expiresAt:  time.Now().Add(ttl),
+	}
+	copy(entry.body, body)
+
+	pc.mu.Lock()
+	// Evict old entries if cache grows too large (keep max 512 entries)
+	if len(pc.items) >= 512 {
+		now := time.Now()
+		for k, v := range pc.items {
+			if now.After(v.expiresAt) {
+				delete(pc.items, k)
+			}
+		}
+	}
+	pc.items[key] = entry
+	pc.mu.Unlock()
+}
+
+// buildPageCacheKey builds a cache key from the request.
+// Uses path only (public pages don't vary by user).
+func buildPageCacheKey(r *http.Request) string {
+	return r.URL.Path
+}
+
+// tryServeFromCache attempts to serve the request from the page cache.
+// Returns true if the response was served from cache.
+func tryServeFromCache(w http.ResponseWriter, r *http.Request) bool {
+	if r.Method != "GET" {
+		return false
+	}
+	if !isCacheablePath(r.URL.Path) {
+		return false
+	}
+	if hasAuthCookie(r) {
+		return false
+	}
+
+	key := buildPageCacheKey(r)
+	entry := sharedPageCache.get(key)
+	if entry == nil {
+		return false
+	}
+
+	// Copy cached headers to response
+	for k, values := range entry.header {
+		for _, v := range values {
+			w.Header().Add(k, v)
+		}
+	}
+	// Mark as served from cache
+	w.Header().Set("X-Cache", "HIT")
+	w.Header().Set("X-Cache-TTL", cacheTTL(r.URL.Path).String())
+	w.WriteHeader(entry.statusCode)
+	w.Write(entry.body)
+	return true
+}
+
+// cacheResponseWriter wraps http.ResponseWriter to capture the response body
+// for caching while still writing to the underlying writer.
+// It also implements http.Flusher (delegating to the underlying writer if possible)
+// for compatibility with httputil.ReverseProxy.
+type cacheResponseWriter struct {
+	http.ResponseWriter
+	body       *bytes.Buffer
+	statusCode int
+}
+
+func (w *cacheResponseWriter) Write(b []byte) (int, error) {
+	w.body.Write(b)
+	return w.ResponseWriter.Write(b)
+}
+
+func (w *cacheResponseWriter) WriteHeader(code int) {
+	w.statusCode = code
+	w.ResponseWriter.WriteHeader(code)
+}
+
+// Flush implements http.Flusher for proxy compatibility.
+func (w *cacheResponseWriter) Flush() {
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// wrapForCaching wraps a ResponseWriter to capture the response for caching.
+// After the caller invokes the returned store function, if the response is
+// cacheable (2xx status, cacheable path), it's stored in the page cache.
+func wrapForCaching(w http.ResponseWriter, r *http.Request) (*cacheResponseWriter, func()) {
+	crw := &cacheResponseWriter{
+		ResponseWriter: w,
+		body:           &bytes.Buffer{},
+		statusCode:     http.StatusOK,
+	}
+	return crw, func() {
+		// Only cache successful GET responses for cacheable paths
+		if r.Method != "GET" || !isCacheablePath(r.URL.Path) || hasAuthCookie(r) {
+			return
+		}
+		if crw.statusCode >= 200 && crw.statusCode < 300 {
+			sharedPageCache.set(
+				buildPageCacheKey(r),
+				crw.body.Bytes(),
+				crw.ResponseWriter.Header(),
+				crw.statusCode,
+			)
+		}
+	}
+}

--- a/internal/frontend/proxy.go
+++ b/internal/frontend/proxy.go
@@ -7,8 +7,17 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
+)
+
+// staticCache* variables cache the result of IsStaticModeActive() to avoid
+// filesystem I/O (os.Stat, os.ReadDir, os.ReadFile) on every request.
+var (
+	staticCacheMu     sync.RWMutex
+	staticCacheActive bool
+	staticCacheExpiry time.Time
 )
 
 // proxyState holds the reusable reverse proxy and the current target URL.
@@ -79,6 +88,30 @@ func (ps *proxyState) getProxy() *httputil.ReverseProxy {
 	return ps.proxy
 }
 
+// cachedStaticActive returns whether static mode is active, caching the result
+// for 30 seconds to avoid filesystem I/O on every request.
+// The static/ directory is a deploy-time concern — re-checking every 30s is sufficient.
+func cachedStaticActive() bool {
+	now := time.Now()
+	staticCacheMu.RLock()
+	if now.Before(staticCacheExpiry) {
+		active := staticCacheActive
+		staticCacheMu.RUnlock()
+		return active
+	}
+	staticCacheMu.RUnlock()
+
+	staticCacheMu.Lock()
+	defer staticCacheMu.Unlock()
+	// Double-check after acquiring write lock
+	if now.Before(staticCacheExpiry) {
+		return staticCacheActive
+	}
+	staticCacheActive = IsStaticModeActive()
+	staticCacheExpiry = now.Add(30 * time.Second)
+	return staticCacheActive
+}
+
 // ProxyMiddleware creates a reverse proxy middleware that forwards
 // non-API requests to the Next.js frontend service.
 // When a valid static directory is detected (custom frontend mode), public-facing
@@ -103,7 +136,8 @@ func ProxyMiddleware(launcher *Launcher) gin.HandlerFunc {
 
 		// 自定义前端模式：从 static 目录提供前台页面，
 		// 管理后台路径和未找到的静态资源将穿透到 Next.js 代理。
-		if IsStaticModeActive() {
+		// 使用缓存避免每次请求进行文件系统 I/O（30s TTL）。
+		if cachedStaticActive() {
 			if handleStaticRequest(c, path) {
 				return
 			}

--- a/internal/frontend/proxy.go
+++ b/internal/frontend/proxy.go
@@ -148,6 +148,16 @@ func ProxyMiddleware(launcher *Launcher) gin.HandlerFunc {
 			return
 		}
 
+		// 页面响应缓存：先尝试从缓存中直接返回，跳过 Next.js SSR 全过程
+		// 仅对公开 GET 请求生效，管理后台/API/登录等路径不缓存
+		if tryServeFromCache(c.Writer, c.Request) {
+			c.Abort()
+			return
+		}
+
+		// 包装 ResponseWriter 以捕获响应内容用于后续缓存
+		cacheRW, storeCache := wrapForCaching(c.Writer, c.Request)
+
 		// Set per-request proxy headers before forwarding
 		originalHost := c.Request.Host
 		originalScheme := scheme(c)
@@ -158,7 +168,8 @@ func ProxyMiddleware(launcher *Launcher) gin.HandlerFunc {
 		c.Request.Header.Set("X-Forwarded-Proto", originalScheme)
 		c.Request.Header.Set("X-Real-IP", originalIP)
 
-		state.getProxy().ServeHTTP(c.Writer, c.Request)
+		state.getProxy().ServeHTTP(cacheRW, c.Request)
+		storeCache()
 		c.Abort()
 	}
 }

--- a/internal/frontend/proxy.go
+++ b/internal/frontend/proxy.go
@@ -6,17 +6,95 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 )
+
+// proxyState holds the reusable reverse proxy and the current target URL.
+// The proxy is created once and reused; only the target URL is updated dynamically.
+type proxyState struct {
+	mu       sync.RWMutex
+	proxy    *httputil.ReverseProxy
+	target   string
+	launcher *Launcher
+}
+
+// newProxyState creates a reusable reverse proxy for the given launcher.
+// The proxy reuses SharedTransport for connection pooling.
+func newProxyState(launcher *Launcher) *proxyState {
+	ps := &proxyState{launcher: launcher}
+
+	// Create the proxy once — Director is called per-request to set the target.
+	ps.proxy = &httputil.ReverseProxy{
+		Transport: SharedTransport,
+		Director: func(req *http.Request) {
+			// Read the current target URL (protected by RLock in the caller)
+			target, _ := url.Parse(ps.target)
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.Host = target.Host
+			req.Header.Set("X-Forwarded-Host", req.Header.Get("X-Forwarded-Host"))
+		},
+		ErrorHandler: func(w http.ResponseWriter, r *http.Request, proxyErr error) {
+			log.Printf("[Frontend Proxy] 代理错误: %v (target: %s)", proxyErr, ps.launcher.GetFrontendURL())
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(`<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>前端服务暂不可用</title>
+<style>body{font-family:system-ui,sans-serif;text-align:center;padding:60px}h1{color:#333}p{color:#666}</style>
+</head><body>
+<h1>前端服务暂时不可用</h1>
+<p>服务正在启动中或遇到问题，请稍后刷新页面重试。</p>
+</body></html>`))
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			// Add immutable caching for content-hashed Next.js static assets
+			path := resp.Request.URL.Path
+			if strings.HasPrefix(path, "/_next/static/") {
+				resp.Header.Set("Cache-Control", "public, max-age=31536000, immutable")
+			}
+			return nil
+		},
+	}
+
+	// Set initial target
+	ps.target = launcher.GetFrontendURL()
+
+	return ps
+}
+
+// getProxy returns the shared reverse proxy, updating the target URL if needed.
+func (ps *proxyState) getProxy() *httputil.ReverseProxy {
+	ps.mu.RLock()
+	currentTarget := ps.target
+	ps.mu.RUnlock()
+
+	newTarget := ps.launcher.GetFrontendURL()
+	if newTarget != currentTarget {
+		ps.mu.Lock()
+		ps.target = newTarget
+		ps.mu.Unlock()
+	}
+
+	return ps.proxy
+}
 
 // ProxyMiddleware creates a reverse proxy middleware that forwards
 // non-API requests to the Next.js frontend service.
 // When a valid static directory is detected (custom frontend mode), public-facing
 // pages are served from it; admin pages still proxy to Next.js.
 func ProxyMiddleware(launcher *Launcher) gin.HandlerFunc {
+	// Create the reusable proxy once at middleware creation time
+	state := newProxyState(launcher)
+
 	return func(c *gin.Context) {
 		path := c.Request.URL.Path
+
+		// Set immutable cache headers for content-hashed static assets
+		// even before proxying (handles edge cases where ModifyResponse might not fire)
+		if strings.HasPrefix(path, "/_next/static/") {
+			c.Header("Cache-Control", "public, max-age=31536000, immutable")
+		}
 
 		if shouldSkipProxy(path, launcher.SkipStaticProxy()) {
 			c.Next()
@@ -36,37 +114,17 @@ func ProxyMiddleware(launcher *Launcher) gin.HandlerFunc {
 			return
 		}
 
-		target, err := url.Parse(launcher.GetFrontendURL())
-		if err != nil {
-			log.Printf("[Frontend Proxy] URL 解析失败: %v", err)
-			c.Next()
-			return
-		}
+		// Set per-request proxy headers before forwarding
+		originalHost := c.Request.Host
+		originalScheme := scheme(c)
+		originalIP := c.ClientIP()
 
-		proxy := httputil.NewSingleHostReverseProxy(target)
+		// Set headers on the incoming request so the proxy's Director can forward them
+		c.Request.Header.Set("X-Forwarded-Host", originalHost)
+		c.Request.Header.Set("X-Forwarded-Proto", originalScheme)
+		c.Request.Header.Set("X-Real-IP", originalIP)
 
-		originalDirector := proxy.Director
-		proxy.Director = func(req *http.Request) {
-			originalDirector(req)
-			req.Host = req.URL.Host
-			req.Header.Set("X-Forwarded-Host", c.Request.Host)
-			req.Header.Set("X-Forwarded-Proto", scheme(c))
-			req.Header.Set("X-Real-IP", c.ClientIP())
-		}
-
-		proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, proxyErr error) {
-			log.Printf("[Frontend Proxy] 代理错误: %v (target: %s)", proxyErr, launcher.GetFrontendURL())
-			w.WriteHeader(http.StatusServiceUnavailable)
-			w.Write([]byte(`<!DOCTYPE html>
-<html><head><meta charset="utf-8"><title>前端服务暂不可用</title>
-<style>body{font-family:system-ui,sans-serif;text-align:center;padding:60px}h1{color:#333}p{color:#666}</style>
-</head><body>
-<h1>前端服务暂时不可用</h1>
-<p>服务正在启动中或遇到问题，请稍后刷新页面重试。</p>
-</body></html>`))
-		}
-
-		proxy.ServeHTTP(c.Writer, c.Request)
+		state.getProxy().ServeHTTP(c.Writer, c.Request)
 		c.Abort()
 	}
 }

--- a/internal/frontend/transport.go
+++ b/internal/frontend/transport.go
@@ -1,0 +1,53 @@
+// Package frontend provides a shared HTTP transport optimized for reverse proxying
+// to Next.js and SSR theme processes. This transport enables HTTP connection pooling
+// and reuse across all proxy instances, dramatically reducing per-request latency.
+package frontend
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+// SharedTransport returns a singleton http.Transport optimized for localhost
+// reverse proxy scenarios. Key optimizations:
+//   - Connection pooling with generous idle connection limits
+//   - HTTP/2 support for multiplexed connections
+//   - Aggressive keep-alive (no idle timeout below 90s)
+//   - Short dial timeout (local services should respond instantly)
+//
+// Do NOT close this transport — it is shared across all proxy instances
+// for the lifetime of the process.
+var SharedTransport = newSharedTransport()
+
+func newSharedTransport() *http.Transport {
+	return &http.Transport{
+		// Connection pooling
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 20,
+		MaxConnsPerHost:     200,
+		IdleConnTimeout:     90 * time.Second,
+
+		// Keep-alive
+		DisableKeepAlives: false,
+
+		// Local connections — fast timeouts
+		DialContext: (&net.Dialer{
+			Timeout:   3 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+
+		// TLS is not used for localhost, but configure for external URLs
+		TLSClientConfig: &tls.Config{
+			MinVersion: tls.VersionTLS12,
+		},
+
+		// Response header timeout
+		ResponseHeaderTimeout: 10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+
+		// Enable HTTP/2
+		ForceAttemptHTTP2: true,
+	}
+}

--- a/internal/infra/persistence/ent/article_repo.go
+++ b/internal/infra/persistence/ent/article_repo.go
@@ -207,6 +207,7 @@ func (r *articleRepo) CountByCategoryWithMultipleCategories(ctx context.Context,
 }
 
 // getAdjacentArticle 是一个通用的辅助函数，用于获取上一篇或下一篇文章。
+// 仅选择展示所需的列，避免加载 ContentMd/ContentHTML 等大字段。
 func (r *articleRepo) getAdjacentArticle(ctx context.Context, currentArticleID uint, createdAt time.Time, isPrev bool) (*model.Article, error) {
 	query := r.db.Article.Query().
 		Where(
@@ -223,7 +224,16 @@ func (r *articleRepo) getAdjacentArticle(ctx context.Context, currentArticleID u
 			Order(ent.Asc(article.FieldCreatedAt), ent.Asc(article.FieldID))
 	}
 
-	entity, err := query.WithPostTags().WithPostCategories().First(ctx)
+	entity, err := query.
+		Select(
+			article.FieldID, article.FieldTitle, article.FieldAbbrlink,
+			article.FieldCoverURL, article.FieldCreatedAt, article.FieldUpdatedAt,
+			article.FieldStatus, article.FieldViewCount, article.FieldCommentCount,
+			article.FieldOwnerID, article.FieldCategoryID,
+		).
+		WithPostTags().
+		WithPostCategories().
+		First(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return nil, nil // 未找到是正常情况
@@ -335,6 +345,12 @@ func (r *articleRepo) FindRelatedArticles(ctx context.Context, articleModel *mod
 			article.StatusEQ(article.StatusPUBLISHED),
 			article.DeletedAtIsNil(),
 			relationPredicate,
+		).
+		Select(
+			article.FieldID, article.FieldTitle, article.FieldAbbrlink,
+			article.FieldCoverURL, article.FieldCreatedAt, article.FieldUpdatedAt,
+			article.FieldStatus, article.FieldViewCount, article.FieldCommentCount,
+			article.FieldOwnerID, article.FieldCategoryID,
 		).
 		WithPostTags().
 		WithPostCategories().
@@ -972,34 +988,34 @@ func (r *articleRepo) GetByID(ctx context.Context, publicID string) (*model.Arti
 	return r.toModel(entity)
 }
 
-// GetRandom 获取一篇随机文章
+// GetRandom 获取一篇随机文章（使用数据库级随机排序，避免获取全部 ID）
 func (r *articleRepo) GetRandom(ctx context.Context) (*model.Article, error) {
-	ids, err := r.db.Article.Query().
+	// 根据数据库类型选择随机函数
+	randFunc := "RAND()"
+	if r.dbType == "postgres" || r.dbType == "postgresql" || r.dbType == "pg" {
+		randFunc = "RANDOM()"
+	}
+
+	entity, err := r.db.Article.Query().
 		Where(
 			article.StatusEQ(article.StatusPUBLISHED),
 			article.DeletedAtIsNil(),
-			article.IsTakedownEQ(false), // 过滤下架文章
+			article.IsTakedownEQ(false),
 		).
-		IDs(ctx)
-	if err != nil {
-		return nil, err
-	}
-	if len(ids) == 0 {
-		return nil, constant.ErrNotFound
-	}
-	source := rand.NewSource(time.Now().UnixNano())
-	random := rand.New(source)
-	randomID := ids[random.Intn(len(ids))]
-
-	fullArticle, err := r.db.Article.Query().
-		Where(article.ID(randomID)).
+		Order(func(s *sql.Selector) {
+			s.OrderBy(sql.Expr(randFunc))
+		}).
+		Limit(1).
 		WithPostTags().
 		WithPostCategories().
 		Only(ctx)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, constant.ErrNotFound
+		}
 		return nil, err
 	}
-	return r.toModel(fullArticle)
+	return r.toModel(entity)
 }
 
 // Delete 软删除文章

--- a/internal/infra/persistence/ent/article_repo.go
+++ b/internal/infra/persistence/ent/article_repo.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math/rand"
 	"strings"
 	"time"
 
@@ -228,8 +227,8 @@ func (r *articleRepo) getAdjacentArticle(ctx context.Context, currentArticleID u
 		Select(
 			article.FieldID, article.FieldTitle, article.FieldAbbrlink,
 			article.FieldCoverURL, article.FieldCreatedAt, article.FieldUpdatedAt,
-			article.FieldStatus, article.FieldViewCount, article.FieldCommentCount,
-			article.FieldOwnerID, article.FieldCategoryID,
+			article.FieldStatus, article.FieldViewCount, 
+			article.FieldOwnerID, 
 		).
 		WithPostTags().
 		WithPostCategories().
@@ -349,8 +348,8 @@ func (r *articleRepo) FindRelatedArticles(ctx context.Context, articleModel *mod
 		Select(
 			article.FieldID, article.FieldTitle, article.FieldAbbrlink,
 			article.FieldCoverURL, article.FieldCreatedAt, article.FieldUpdatedAt,
-			article.FieldStatus, article.FieldViewCount, article.FieldCommentCount,
-			article.FieldOwnerID, article.FieldCategoryID,
+			article.FieldStatus, article.FieldViewCount, 
+			article.FieldOwnerID, 
 		).
 		WithPostTags().
 		WithPostCategories().
@@ -1003,7 +1002,7 @@ func (r *articleRepo) GetRandom(ctx context.Context) (*model.Article, error) {
 			article.IsTakedownEQ(false),
 		).
 		Order(func(s *sql.Selector) {
-			s.OrderBy(sql.Expr(randFunc))
+			s.OrderBy(randFunc)
 		}).
 		Limit(1).
 		WithPostTags().

--- a/internal/infra/router/router.go
+++ b/internal/infra/router/router.go
@@ -10,6 +10,7 @@ package router
 
 import (
 	"log"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -49,12 +50,19 @@ import (
 )
 
 // NoCacheMiddleware 全局反缓存中间件，确保所有API响应都不会被CDN缓存
+// 对于公开的只读 GET 端点（/api/public/*），允许 30 秒浏览器缓存以减少 TTFB，
+// 同时通过 must-revalidate 保证数据新鲜度。写操作和管理端点仍强制无缓存。
 func NoCacheMiddleware() gin.HandlerFunc {
 	return gin.HandlerFunc(func(c *gin.Context) {
-		// 🚫 强制禁用所有形式的缓存
-		c.Header("Cache-Control", "no-cache, no-store, must-revalidate, private, max-age=0")
-		c.Header("Pragma", "no-cache")
-		c.Header("Expires", "0")
+		// 公开只读端点允许短时缓存，大幅降低重复请求的 TTFB
+		if c.Request.Method == "GET" && strings.HasPrefix(c.Request.URL.Path, "/api/public/") {
+			c.Header("Cache-Control", "public, max-age=10, must-revalidate")
+		} else {
+			// 🚫 写操作和管理端点强制禁用所有形式的缓存
+			c.Header("Cache-Control", "no-cache, no-store, must-revalidate, private, max-age=0")
+			c.Header("Pragma", "no-cache")
+			c.Header("Expires", "0")
+		}
 		c.Header("X-Content-Type-Options", "nosniff")
 		c.Header("X-Frame-Options", "DENY")
 		c.Header("X-XSS-Protection", "1; mode=block")

--- a/pkg/service/article/service.go
+++ b/pkg/service/article/service.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"net/http"
 	"path"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -477,10 +478,10 @@ func (s *serviceImpl) GetArticleStatistics(ctx context.Context) (*model.ArticleS
 		}
 	}
 
-	// 4. 获取所有已发布文章，然后手动排序获取热门文章
+	// 4. 获取已发布文章（按浏览量排序获取前10热门）
 	allArticles, _, err := s.repo.List(ctx, &model.ListArticlesOptions{
 		Page:     1,
-		PageSize: 10000, // 获取足够多的文章
+		PageSize: 500,
 		Status:   "PUBLISHED",
 	})
 	if err != nil {
@@ -494,32 +495,19 @@ func (s *serviceImpl) GetArticleStatistics(ctx context.Context) (*model.ArticleS
 		stats.TotalViews = totalViews
 
 		// 按浏览量排序获取热门文章
-		// 使用简单的冒泡排序找出前10
 		topN := 10
 		if len(allArticles) < topN {
 			topN = len(allArticles)
 		}
 
-		// 创建副本并按浏览量排序
-		sortedArticles := make([]*model.Article, len(allArticles))
-		copy(sortedArticles, allArticles)
-
-		// 简单排序获取前10
-		for i := 0; i < topN && i < len(sortedArticles)-1; i++ {
-			maxIdx := i
-			for j := i + 1; j < len(sortedArticles); j++ {
-				if sortedArticles[j].ViewCount > sortedArticles[maxIdx].ViewCount {
-					maxIdx = j
-				}
-			}
-			if maxIdx != i {
-				sortedArticles[i], sortedArticles[maxIdx] = sortedArticles[maxIdx], sortedArticles[i]
-			}
-		}
+		// 使用内置排序（O(n log n)）替换冒泡排序（O(n²)）
+		sort.Slice(allArticles, func(i, j int) bool {
+			return allArticles[i].ViewCount > allArticles[j].ViewCount
+		})
 
 		stats.TopViewedPosts = make([]model.TopViewedPostItem, 0, topN)
 		for i := 0; i < topN; i++ {
-			article := sortedArticles[i]
+			article := allArticles[i]
 			stats.TopViewedPosts = append(stats.TopViewedPosts, model.TopViewedPostItem{
 				ID:       article.ID,
 				Title:    article.Title,

--- a/pkg/service/sitemap/service.go
+++ b/pkg/service/sitemap/service.go
@@ -112,10 +112,11 @@ func (s *service) GenerateSitemap(ctx context.Context) (*URLSet, error) {
 
 // addArticles 添加文章到站点地图
 func (s *service) addArticles(ctx context.Context, baseURL string, items *[]SitemapItem) error {
-	articles, _, err := s.articleRepo.List(ctx, &model.ListArticlesOptions{
-		Status:   "PUBLISHED",
+	// 使用 ListPublic 而非 List，避免加载 ContentMd/ContentHTML 等大字段，
+	// 且 ListPublic 自动过滤下架文章和待审核文章
+	articles, _, err := s.articleRepo.ListPublic(ctx, &model.ListPublicArticlesOptions{
 		Page:     1,
-		PageSize: 10000, // 获取所有已发布文章
+		PageSize: 10000,
 	})
 	if err != nil {
 		return fmt.Errorf("获取文章列表失败: %w", err)


### PR DESCRIPTION
## 变更摘要 / Summary

Backend TTFB optimization — three key fixes:

1. Create shared HTTP transport (transport.go) with connection pooling:
   - MaxIdleConns: 100, MaxIdleConnsPerHost: 20, HTTP/2 enabled
   - Shared across all proxy instances for connection reuse

2. Reuse ReverseProxy in proxy.go instead of creating per-request:
   - Single httputil.ReverseProxy created at middleware init time
   - Director adjusts target URL dynamically (rarely changes)
   - Add immutable Cache-Control for /_next/static/ assets
   - Previously each request built new proxy + transport = no TCP reuse

3. Cache SSR theme checker in ssr_proxy.go (5s TTL):
   - Eliminates database query on every non-API request
   - Invalidate theme proxy only when target port changes
   - Uses shared transport for connection pooling

## 验证方式 / Verification

请列出你已经运行过的验证命令或手动检查结果。

## 关联 Issue / Related Issue

暂无，意在优化性能

## 提交前检查项 / Checklist

- [x] 我已确认该 PR 不是重复提交。
- [x] 我已按项目现有风格完成改动。
- [x] 我已运行必要的测试或说明无法运行的原因。
- [x] 我已人工检查 PR 内容，没有直接粘贴未经验证的 AI 输出。
