### PR TITLE
fix(article): 修复无标题草稿自动保存

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ themes
 backup
 static
 DEVELOPMENT_WORKFLOW.md
+/data/*.db

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1643,6 +1643,13 @@ const docTemplate = `{
                 "summary": "创建新文章",
                 "parameters": [
                     {
+                        "maxLength": 200,
+                        "type": "string",
+                        "description": "可选的创建幂等键，最长 200 字节",
+                        "name": "Idempotency-Key",
+                        "in": "header"
+                    },
+                    {
                         "description": "创建文章的请求体",
                         "name": "article",
                         "in": "body",
@@ -1673,6 +1680,12 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/response.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "幂等键或文章数据冲突",
                         "schema": {
                             "$ref": "#/definitions/response.Response"
                         }
@@ -2194,6 +2207,18 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/response.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "文章不存在",
+                        "schema": {
+                            "$ref": "#/definitions/response.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "文章状态或数据冲突",
                         "schema": {
                             "$ref": "#/definitions/response.Response"
                         }
@@ -14128,9 +14153,6 @@ const docTemplate = `{
         },
         "model.CreateArticleRequest": {
             "type": "object",
-            "required": [
-                "title"
-            ],
             "properties": {
                 "abbrlink": {
                     "type": "string"
@@ -14246,6 +14268,7 @@ const docTemplate = `{
                     }
                 },
                 "title": {
+                    "description": "草稿允许暂时先不设置标题",
                     "type": "string"
                 },
                 "top_img_url": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1632,6 +1632,13 @@
                 "summary": "创建新文章",
                 "parameters": [
                     {
+                        "maxLength": 200,
+                        "type": "string",
+                        "description": "可选的创建幂等键，最长 200 字节",
+                        "name": "Idempotency-Key",
+                        "in": "header"
+                    },
+                    {
                         "description": "创建文章的请求体",
                         "name": "article",
                         "in": "body",
@@ -1662,6 +1669,12 @@
                     },
                     "400": {
                         "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/response.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "幂等键或文章数据冲突",
                         "schema": {
                             "$ref": "#/definitions/response.Response"
                         }
@@ -2183,6 +2196,18 @@
                     },
                     "400": {
                         "description": "请求参数错误",
+                        "schema": {
+                            "$ref": "#/definitions/response.Response"
+                        }
+                    },
+                    "404": {
+                        "description": "文章不存在",
+                        "schema": {
+                            "$ref": "#/definitions/response.Response"
+                        }
+                    },
+                    "409": {
+                        "description": "文章状态或数据冲突",
                         "schema": {
                             "$ref": "#/definitions/response.Response"
                         }
@@ -14117,9 +14142,6 @@
         },
         "model.CreateArticleRequest": {
             "type": "object",
-            "required": [
-                "title"
-            ],
             "properties": {
                 "abbrlink": {
                     "type": "string"
@@ -14235,6 +14257,7 @@
                     }
                 },
                 "title": {
+                    "description": "草稿允许暂时先不设置标题",
                     "type": "string"
                 },
                 "top_img_url": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1248,11 +1248,10 @@ definitions:
           type: string
         type: array
       title:
+        description: 草稿允许暂时先不设置标题
         type: string
       top_img_url:
         type: string
-    required:
-    - title
     type: object
   model.CreateDocSeriesRequest:
     properties:
@@ -3917,6 +3916,11 @@ paths:
       - application/json
       description: 根据提供的请求体创建一个新文章。总字数、阅读时长和IP属地由后端自动计算。
       parameters:
+      - description: 可选的创建幂等键，最长 200 字节
+        in: header
+        maxLength: 200
+        name: Idempotency-Key
+        type: string
       - description: 创建文章的请求体
         in: body
         name: article
@@ -3937,6 +3941,10 @@ paths:
               type: object
         "400":
           description: 请求参数错误
+          schema:
+            $ref: '#/definitions/response.Response'
+        "409":
+          description: 幂等键或文章数据冲突
           schema:
             $ref: '#/definitions/response.Response'
         "500":
@@ -4034,6 +4042,14 @@ paths:
               type: object
         "400":
           description: 请求参数错误
+          schema:
+            $ref: '#/definitions/response.Response'
+        "404":
+          description: 文章不存在
+          schema:
+            $ref: '#/definitions/response.Response'
+        "409":
+          description: 文章状态或数据冲突
           schema:
             $ref: '#/definitions/response.Response'
         "500":

--- a/ent/article.go
+++ b/ent/article.go
@@ -29,6 +29,10 @@ type Article struct {
 	UpdatedAt time.Time `json:"updated_at,omitempty"`
 	// 文章标题
 	Title string `json:"title,omitempty"`
+	// 创建文章使用的内部幂等键摘要
+	CreateIdempotencyKey *string `json:"-"`
+	// 创建文章请求的内部摘要
+	CreateRequestDigest *string `json:"-"`
 	// 文章的 Markdown 原文
 	ContentMd string `json:"content_md,omitempty"`
 	// 由 content_md 解析和净化后的 HTML
@@ -188,7 +192,7 @@ func (*Article) scanValues(columns []string) ([]any, error) {
 			values[i] = new(sql.NullBool)
 		case article.FieldID, article.FieldOwnerID, article.FieldViewCount, article.FieldWordCount, article.FieldReadingTime, article.FieldHomeSort, article.FieldPinSort, article.FieldReviewedBy, article.FieldTakedownBy, article.FieldDocSeriesID, article.FieldDocSort:
 			values[i] = new(sql.NullInt64)
-		case article.FieldTitle, article.FieldContentMd, article.FieldContentHTML, article.FieldCoverURL, article.FieldStatus, article.FieldIPLocation, article.FieldPrimaryColor, article.FieldTopImgURL, article.FieldAbbrlink, article.FieldCopyrightAuthor, article.FieldCopyrightAuthorHref, article.FieldCopyrightURL, article.FieldKeywords, article.FieldReviewStatus, article.FieldReviewComment, article.FieldTakedownReason:
+		case article.FieldTitle, article.FieldCreateIdempotencyKey, article.FieldCreateRequestDigest, article.FieldContentMd, article.FieldContentHTML, article.FieldCoverURL, article.FieldStatus, article.FieldIPLocation, article.FieldPrimaryColor, article.FieldTopImgURL, article.FieldAbbrlink, article.FieldCopyrightAuthor, article.FieldCopyrightAuthorHref, article.FieldCopyrightURL, article.FieldKeywords, article.FieldReviewStatus, article.FieldReviewComment, article.FieldTakedownReason:
 			values[i] = new(sql.NullString)
 		case article.FieldDeletedAt, article.FieldCreatedAt, article.FieldUpdatedAt, article.FieldScheduledAt, article.FieldReviewedAt, article.FieldTakedownAt:
 			values[i] = new(sql.NullTime)
@@ -243,6 +247,20 @@ func (_m *Article) assignValues(columns []string, values []any) error {
 				return fmt.Errorf("unexpected type %T for field title", values[i])
 			} else if value.Valid {
 				_m.Title = value.String
+			}
+		case article.FieldCreateIdempotencyKey:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field create_idempotency_key", values[i])
+			} else if value.Valid {
+				_m.CreateIdempotencyKey = new(string)
+				*_m.CreateIdempotencyKey = value.String
+			}
+		case article.FieldCreateRequestDigest:
+			if value, ok := values[i].(*sql.NullString); !ok {
+				return fmt.Errorf("unexpected type %T for field create_request_digest", values[i])
+			} else if value.Valid {
+				_m.CreateRequestDigest = new(string)
+				*_m.CreateRequestDigest = value.String
 			}
 		case article.FieldContentMd:
 			if value, ok := values[i].(*sql.NullString); !ok {
@@ -566,6 +584,10 @@ func (_m *Article) String() string {
 	builder.WriteString(", ")
 	builder.WriteString("title=")
 	builder.WriteString(_m.Title)
+	builder.WriteString(", ")
+	builder.WriteString("create_idempotency_key=<sensitive>")
+	builder.WriteString(", ")
+	builder.WriteString("create_request_digest=<sensitive>")
 	builder.WriteString(", ")
 	builder.WriteString("content_md=")
 	builder.WriteString(_m.ContentMd)

--- a/ent/article/article.go
+++ b/ent/article/article.go
@@ -230,8 +230,8 @@ var (
 	DefaultCreatedAt func() time.Time
 	// DefaultUpdatedAt holds the default value on creation for the "updated_at" field.
 	DefaultUpdatedAt func() time.Time
-	// TitleValidator is a validator for the "title" field. It is called by the builders before save.
-	TitleValidator func(string) error
+	// DefaultTitle holds the default value on creation for the "title" field.
+	DefaultTitle string
 	// DefaultViewCount holds the default value on creation for the "view_count" field.
 	DefaultViewCount int
 	// ViewCountValidator is a validator for the "view_count" field. It is called by the builders before save.

--- a/ent/article/article.go
+++ b/ent/article/article.go
@@ -26,6 +26,10 @@ const (
 	FieldUpdatedAt = "updated_at"
 	// FieldTitle holds the string denoting the title field in the database.
 	FieldTitle = "title"
+	// FieldCreateIdempotencyKey holds the string denoting the create_idempotency_key field in the database.
+	FieldCreateIdempotencyKey = "create_idempotency_key"
+	// FieldCreateRequestDigest holds the string denoting the create_request_digest field in the database.
+	FieldCreateRequestDigest = "create_request_digest"
 	// FieldContentMd holds the string denoting the content_md field in the database.
 	FieldContentMd = "content_md"
 	// FieldContentHTML holds the string denoting the content_html field in the database.
@@ -157,6 +161,8 @@ var Columns = []string{
 	FieldCreatedAt,
 	FieldUpdatedAt,
 	FieldTitle,
+	FieldCreateIdempotencyKey,
+	FieldCreateRequestDigest,
 	FieldContentMd,
 	FieldContentHTML,
 	FieldCoverURL,
@@ -232,6 +238,10 @@ var (
 	DefaultUpdatedAt func() time.Time
 	// DefaultTitle holds the default value on creation for the "title" field.
 	DefaultTitle string
+	// CreateIdempotencyKeyValidator is a validator for the "create_idempotency_key" field. It is called by the builders before save.
+	CreateIdempotencyKeyValidator func(string) error
+	// CreateRequestDigestValidator is a validator for the "create_request_digest" field. It is called by the builders before save.
+	CreateRequestDigestValidator func(string) error
 	// DefaultViewCount holds the default value on creation for the "view_count" field.
 	DefaultViewCount int
 	// ViewCountValidator is a validator for the "view_count" field. It is called by the builders before save.
@@ -367,6 +377,16 @@ func ByUpdatedAt(opts ...sql.OrderTermOption) OrderOption {
 // ByTitle orders the results by the title field.
 func ByTitle(opts ...sql.OrderTermOption) OrderOption {
 	return sql.OrderByField(FieldTitle, opts...).ToFunc()
+}
+
+// ByCreateIdempotencyKey orders the results by the create_idempotency_key field.
+func ByCreateIdempotencyKey(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCreateIdempotencyKey, opts...).ToFunc()
+}
+
+// ByCreateRequestDigest orders the results by the create_request_digest field.
+func ByCreateRequestDigest(opts ...sql.OrderTermOption) OrderOption {
+	return sql.OrderByField(FieldCreateRequestDigest, opts...).ToFunc()
 }
 
 // ByContentMd orders the results by the content_md field.

--- a/ent/article/where.go
+++ b/ent/article/where.go
@@ -80,6 +80,16 @@ func Title(v string) predicate.Article {
 	return predicate.Article(sql.FieldEQ(FieldTitle, v))
 }
 
+// CreateIdempotencyKey applies equality check predicate on the "create_idempotency_key" field. It's identical to CreateIdempotencyKeyEQ.
+func CreateIdempotencyKey(v string) predicate.Article {
+	return predicate.Article(sql.FieldEQ(FieldCreateIdempotencyKey, v))
+}
+
+// CreateRequestDigest applies equality check predicate on the "create_request_digest" field. It's identical to CreateRequestDigestEQ.
+func CreateRequestDigest(v string) predicate.Article {
+	return predicate.Article(sql.FieldEQ(FieldCreateRequestDigest, v))
+}
+
 // ContentMd applies equality check predicate on the "content_md" field. It's identical to ContentMdEQ.
 func ContentMd(v string) predicate.Article {
 	return predicate.Article(sql.FieldEQ(FieldContentMd, v))
@@ -488,6 +498,156 @@ func TitleEqualFold(v string) predicate.Article {
 // TitleContainsFold applies the ContainsFold predicate on the "title" field.
 func TitleContainsFold(v string) predicate.Article {
 	return predicate.Article(sql.FieldContainsFold(FieldTitle, v))
+}
+
+// CreateIdempotencyKeyEQ applies the EQ predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyEQ(v string) predicate.Article {
+	return predicate.Article(sql.FieldEQ(FieldCreateIdempotencyKey, v))
+}
+
+// CreateIdempotencyKeyNEQ applies the NEQ predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyNEQ(v string) predicate.Article {
+	return predicate.Article(sql.FieldNEQ(FieldCreateIdempotencyKey, v))
+}
+
+// CreateIdempotencyKeyIn applies the In predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyIn(vs ...string) predicate.Article {
+	return predicate.Article(sql.FieldIn(FieldCreateIdempotencyKey, vs...))
+}
+
+// CreateIdempotencyKeyNotIn applies the NotIn predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyNotIn(vs ...string) predicate.Article {
+	return predicate.Article(sql.FieldNotIn(FieldCreateIdempotencyKey, vs...))
+}
+
+// CreateIdempotencyKeyGT applies the GT predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyGT(v string) predicate.Article {
+	return predicate.Article(sql.FieldGT(FieldCreateIdempotencyKey, v))
+}
+
+// CreateIdempotencyKeyGTE applies the GTE predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyGTE(v string) predicate.Article {
+	return predicate.Article(sql.FieldGTE(FieldCreateIdempotencyKey, v))
+}
+
+// CreateIdempotencyKeyLT applies the LT predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyLT(v string) predicate.Article {
+	return predicate.Article(sql.FieldLT(FieldCreateIdempotencyKey, v))
+}
+
+// CreateIdempotencyKeyLTE applies the LTE predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyLTE(v string) predicate.Article {
+	return predicate.Article(sql.FieldLTE(FieldCreateIdempotencyKey, v))
+}
+
+// CreateIdempotencyKeyContains applies the Contains predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyContains(v string) predicate.Article {
+	return predicate.Article(sql.FieldContains(FieldCreateIdempotencyKey, v))
+}
+
+// CreateIdempotencyKeyHasPrefix applies the HasPrefix predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyHasPrefix(v string) predicate.Article {
+	return predicate.Article(sql.FieldHasPrefix(FieldCreateIdempotencyKey, v))
+}
+
+// CreateIdempotencyKeyHasSuffix applies the HasSuffix predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyHasSuffix(v string) predicate.Article {
+	return predicate.Article(sql.FieldHasSuffix(FieldCreateIdempotencyKey, v))
+}
+
+// CreateIdempotencyKeyIsNil applies the IsNil predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyIsNil() predicate.Article {
+	return predicate.Article(sql.FieldIsNull(FieldCreateIdempotencyKey))
+}
+
+// CreateIdempotencyKeyNotNil applies the NotNil predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyNotNil() predicate.Article {
+	return predicate.Article(sql.FieldNotNull(FieldCreateIdempotencyKey))
+}
+
+// CreateIdempotencyKeyEqualFold applies the EqualFold predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyEqualFold(v string) predicate.Article {
+	return predicate.Article(sql.FieldEqualFold(FieldCreateIdempotencyKey, v))
+}
+
+// CreateIdempotencyKeyContainsFold applies the ContainsFold predicate on the "create_idempotency_key" field.
+func CreateIdempotencyKeyContainsFold(v string) predicate.Article {
+	return predicate.Article(sql.FieldContainsFold(FieldCreateIdempotencyKey, v))
+}
+
+// CreateRequestDigestEQ applies the EQ predicate on the "create_request_digest" field.
+func CreateRequestDigestEQ(v string) predicate.Article {
+	return predicate.Article(sql.FieldEQ(FieldCreateRequestDigest, v))
+}
+
+// CreateRequestDigestNEQ applies the NEQ predicate on the "create_request_digest" field.
+func CreateRequestDigestNEQ(v string) predicate.Article {
+	return predicate.Article(sql.FieldNEQ(FieldCreateRequestDigest, v))
+}
+
+// CreateRequestDigestIn applies the In predicate on the "create_request_digest" field.
+func CreateRequestDigestIn(vs ...string) predicate.Article {
+	return predicate.Article(sql.FieldIn(FieldCreateRequestDigest, vs...))
+}
+
+// CreateRequestDigestNotIn applies the NotIn predicate on the "create_request_digest" field.
+func CreateRequestDigestNotIn(vs ...string) predicate.Article {
+	return predicate.Article(sql.FieldNotIn(FieldCreateRequestDigest, vs...))
+}
+
+// CreateRequestDigestGT applies the GT predicate on the "create_request_digest" field.
+func CreateRequestDigestGT(v string) predicate.Article {
+	return predicate.Article(sql.FieldGT(FieldCreateRequestDigest, v))
+}
+
+// CreateRequestDigestGTE applies the GTE predicate on the "create_request_digest" field.
+func CreateRequestDigestGTE(v string) predicate.Article {
+	return predicate.Article(sql.FieldGTE(FieldCreateRequestDigest, v))
+}
+
+// CreateRequestDigestLT applies the LT predicate on the "create_request_digest" field.
+func CreateRequestDigestLT(v string) predicate.Article {
+	return predicate.Article(sql.FieldLT(FieldCreateRequestDigest, v))
+}
+
+// CreateRequestDigestLTE applies the LTE predicate on the "create_request_digest" field.
+func CreateRequestDigestLTE(v string) predicate.Article {
+	return predicate.Article(sql.FieldLTE(FieldCreateRequestDigest, v))
+}
+
+// CreateRequestDigestContains applies the Contains predicate on the "create_request_digest" field.
+func CreateRequestDigestContains(v string) predicate.Article {
+	return predicate.Article(sql.FieldContains(FieldCreateRequestDigest, v))
+}
+
+// CreateRequestDigestHasPrefix applies the HasPrefix predicate on the "create_request_digest" field.
+func CreateRequestDigestHasPrefix(v string) predicate.Article {
+	return predicate.Article(sql.FieldHasPrefix(FieldCreateRequestDigest, v))
+}
+
+// CreateRequestDigestHasSuffix applies the HasSuffix predicate on the "create_request_digest" field.
+func CreateRequestDigestHasSuffix(v string) predicate.Article {
+	return predicate.Article(sql.FieldHasSuffix(FieldCreateRequestDigest, v))
+}
+
+// CreateRequestDigestIsNil applies the IsNil predicate on the "create_request_digest" field.
+func CreateRequestDigestIsNil() predicate.Article {
+	return predicate.Article(sql.FieldIsNull(FieldCreateRequestDigest))
+}
+
+// CreateRequestDigestNotNil applies the NotNil predicate on the "create_request_digest" field.
+func CreateRequestDigestNotNil() predicate.Article {
+	return predicate.Article(sql.FieldNotNull(FieldCreateRequestDigest))
+}
+
+// CreateRequestDigestEqualFold applies the EqualFold predicate on the "create_request_digest" field.
+func CreateRequestDigestEqualFold(v string) predicate.Article {
+	return predicate.Article(sql.FieldEqualFold(FieldCreateRequestDigest, v))
+}
+
+// CreateRequestDigestContainsFold applies the ContainsFold predicate on the "create_request_digest" field.
+func CreateRequestDigestContainsFold(v string) predicate.Article {
+	return predicate.Article(sql.FieldContainsFold(FieldCreateRequestDigest, v))
 }
 
 // ContentMdEQ applies the EQ predicate on the "content_md" field.

--- a/ent/article_create.go
+++ b/ent/article_create.go
@@ -89,6 +89,14 @@ func (_c *ArticleCreate) SetTitle(v string) *ArticleCreate {
 	return _c
 }
 
+// SetNillableTitle sets the "title" field if the given value is not nil.
+func (_c *ArticleCreate) SetNillableTitle(v *string) *ArticleCreate {
+	if v != nil {
+		_c.SetTitle(*v)
+	}
+	return _c
+}
+
 // SetContentMd sets the "content_md" field.
 func (_c *ArticleCreate) SetContentMd(v string) *ArticleCreate {
 	_c.mutation.SetContentMd(v)
@@ -745,6 +753,10 @@ func (_c *ArticleCreate) defaults() error {
 		v := article.DefaultUpdatedAt()
 		_c.mutation.SetUpdatedAt(v)
 	}
+	if _, ok := _c.mutation.Title(); !ok {
+		v := article.DefaultTitle
+		_c.mutation.SetTitle(v)
+	}
 	if _, ok := _c.mutation.Status(); !ok {
 		v := article.DefaultStatus
 		_c.mutation.SetStatus(v)
@@ -837,11 +849,6 @@ func (_c *ArticleCreate) check() error {
 	}
 	if _, ok := _c.mutation.Title(); !ok {
 		return &ValidationError{Name: "title", err: errors.New(`ent: missing required field "Article.title"`)}
-	}
-	if v, ok := _c.mutation.Title(); ok {
-		if err := article.TitleValidator(v); err != nil {
-			return &ValidationError{Name: "title", err: fmt.Errorf(`ent: validator failed for field "Article.title": %w`, err)}
-		}
 	}
 	if _, ok := _c.mutation.Status(); !ok {
 		return &ValidationError{Name: "status", err: errors.New(`ent: missing required field "Article.status"`)}

--- a/ent/article_create.go
+++ b/ent/article_create.go
@@ -97,6 +97,34 @@ func (_c *ArticleCreate) SetNillableTitle(v *string) *ArticleCreate {
 	return _c
 }
 
+// SetCreateIdempotencyKey sets the "create_idempotency_key" field.
+func (_c *ArticleCreate) SetCreateIdempotencyKey(v string) *ArticleCreate {
+	_c.mutation.SetCreateIdempotencyKey(v)
+	return _c
+}
+
+// SetNillableCreateIdempotencyKey sets the "create_idempotency_key" field if the given value is not nil.
+func (_c *ArticleCreate) SetNillableCreateIdempotencyKey(v *string) *ArticleCreate {
+	if v != nil {
+		_c.SetCreateIdempotencyKey(*v)
+	}
+	return _c
+}
+
+// SetCreateRequestDigest sets the "create_request_digest" field.
+func (_c *ArticleCreate) SetCreateRequestDigest(v string) *ArticleCreate {
+	_c.mutation.SetCreateRequestDigest(v)
+	return _c
+}
+
+// SetNillableCreateRequestDigest sets the "create_request_digest" field if the given value is not nil.
+func (_c *ArticleCreate) SetNillableCreateRequestDigest(v *string) *ArticleCreate {
+	if v != nil {
+		_c.SetCreateRequestDigest(*v)
+	}
+	return _c
+}
+
 // SetContentMd sets the "content_md" field.
 func (_c *ArticleCreate) SetContentMd(v string) *ArticleCreate {
 	_c.mutation.SetContentMd(v)
@@ -850,6 +878,16 @@ func (_c *ArticleCreate) check() error {
 	if _, ok := _c.mutation.Title(); !ok {
 		return &ValidationError{Name: "title", err: errors.New(`ent: missing required field "Article.title"`)}
 	}
+	if v, ok := _c.mutation.CreateIdempotencyKey(); ok {
+		if err := article.CreateIdempotencyKeyValidator(v); err != nil {
+			return &ValidationError{Name: "create_idempotency_key", err: fmt.Errorf(`ent: validator failed for field "Article.create_idempotency_key": %w`, err)}
+		}
+	}
+	if v, ok := _c.mutation.CreateRequestDigest(); ok {
+		if err := article.CreateRequestDigestValidator(v); err != nil {
+			return &ValidationError{Name: "create_request_digest", err: fmt.Errorf(`ent: validator failed for field "Article.create_request_digest": %w`, err)}
+		}
+	}
 	if _, ok := _c.mutation.Status(); !ok {
 		return &ValidationError{Name: "status", err: errors.New(`ent: missing required field "Article.status"`)}
 	}
@@ -996,6 +1034,14 @@ func (_c *ArticleCreate) createSpec() (*Article, *sqlgraph.CreateSpec) {
 	if value, ok := _c.mutation.Title(); ok {
 		_spec.SetField(article.FieldTitle, field.TypeString, value)
 		_node.Title = value
+	}
+	if value, ok := _c.mutation.CreateIdempotencyKey(); ok {
+		_spec.SetField(article.FieldCreateIdempotencyKey, field.TypeString, value)
+		_node.CreateIdempotencyKey = &value
+	}
+	if value, ok := _c.mutation.CreateRequestDigest(); ok {
+		_spec.SetField(article.FieldCreateRequestDigest, field.TypeString, value)
+		_node.CreateRequestDigest = &value
 	}
 	if value, ok := _c.mutation.ContentMd(); ok {
 		_spec.SetField(article.FieldContentMd, field.TypeString, value)
@@ -1351,6 +1397,42 @@ func (u *ArticleUpsert) SetTitle(v string) *ArticleUpsert {
 // UpdateTitle sets the "title" field to the value that was provided on create.
 func (u *ArticleUpsert) UpdateTitle() *ArticleUpsert {
 	u.SetExcluded(article.FieldTitle)
+	return u
+}
+
+// SetCreateIdempotencyKey sets the "create_idempotency_key" field.
+func (u *ArticleUpsert) SetCreateIdempotencyKey(v string) *ArticleUpsert {
+	u.Set(article.FieldCreateIdempotencyKey, v)
+	return u
+}
+
+// UpdateCreateIdempotencyKey sets the "create_idempotency_key" field to the value that was provided on create.
+func (u *ArticleUpsert) UpdateCreateIdempotencyKey() *ArticleUpsert {
+	u.SetExcluded(article.FieldCreateIdempotencyKey)
+	return u
+}
+
+// ClearCreateIdempotencyKey clears the value of the "create_idempotency_key" field.
+func (u *ArticleUpsert) ClearCreateIdempotencyKey() *ArticleUpsert {
+	u.SetNull(article.FieldCreateIdempotencyKey)
+	return u
+}
+
+// SetCreateRequestDigest sets the "create_request_digest" field.
+func (u *ArticleUpsert) SetCreateRequestDigest(v string) *ArticleUpsert {
+	u.Set(article.FieldCreateRequestDigest, v)
+	return u
+}
+
+// UpdateCreateRequestDigest sets the "create_request_digest" field to the value that was provided on create.
+func (u *ArticleUpsert) UpdateCreateRequestDigest() *ArticleUpsert {
+	u.SetExcluded(article.FieldCreateRequestDigest)
+	return u
+}
+
+// ClearCreateRequestDigest clears the value of the "create_request_digest" field.
+func (u *ArticleUpsert) ClearCreateRequestDigest() *ArticleUpsert {
+	u.SetNull(article.FieldCreateRequestDigest)
 	return u
 }
 
@@ -2125,6 +2207,48 @@ func (u *ArticleUpsertOne) SetTitle(v string) *ArticleUpsertOne {
 func (u *ArticleUpsertOne) UpdateTitle() *ArticleUpsertOne {
 	return u.Update(func(s *ArticleUpsert) {
 		s.UpdateTitle()
+	})
+}
+
+// SetCreateIdempotencyKey sets the "create_idempotency_key" field.
+func (u *ArticleUpsertOne) SetCreateIdempotencyKey(v string) *ArticleUpsertOne {
+	return u.Update(func(s *ArticleUpsert) {
+		s.SetCreateIdempotencyKey(v)
+	})
+}
+
+// UpdateCreateIdempotencyKey sets the "create_idempotency_key" field to the value that was provided on create.
+func (u *ArticleUpsertOne) UpdateCreateIdempotencyKey() *ArticleUpsertOne {
+	return u.Update(func(s *ArticleUpsert) {
+		s.UpdateCreateIdempotencyKey()
+	})
+}
+
+// ClearCreateIdempotencyKey clears the value of the "create_idempotency_key" field.
+func (u *ArticleUpsertOne) ClearCreateIdempotencyKey() *ArticleUpsertOne {
+	return u.Update(func(s *ArticleUpsert) {
+		s.ClearCreateIdempotencyKey()
+	})
+}
+
+// SetCreateRequestDigest sets the "create_request_digest" field.
+func (u *ArticleUpsertOne) SetCreateRequestDigest(v string) *ArticleUpsertOne {
+	return u.Update(func(s *ArticleUpsert) {
+		s.SetCreateRequestDigest(v)
+	})
+}
+
+// UpdateCreateRequestDigest sets the "create_request_digest" field to the value that was provided on create.
+func (u *ArticleUpsertOne) UpdateCreateRequestDigest() *ArticleUpsertOne {
+	return u.Update(func(s *ArticleUpsert) {
+		s.UpdateCreateRequestDigest()
+	})
+}
+
+// ClearCreateRequestDigest clears the value of the "create_request_digest" field.
+func (u *ArticleUpsertOne) ClearCreateRequestDigest() *ArticleUpsertOne {
+	return u.Update(func(s *ArticleUpsert) {
+		s.ClearCreateRequestDigest()
 	})
 }
 
@@ -3172,6 +3296,48 @@ func (u *ArticleUpsertBulk) SetTitle(v string) *ArticleUpsertBulk {
 func (u *ArticleUpsertBulk) UpdateTitle() *ArticleUpsertBulk {
 	return u.Update(func(s *ArticleUpsert) {
 		s.UpdateTitle()
+	})
+}
+
+// SetCreateIdempotencyKey sets the "create_idempotency_key" field.
+func (u *ArticleUpsertBulk) SetCreateIdempotencyKey(v string) *ArticleUpsertBulk {
+	return u.Update(func(s *ArticleUpsert) {
+		s.SetCreateIdempotencyKey(v)
+	})
+}
+
+// UpdateCreateIdempotencyKey sets the "create_idempotency_key" field to the value that was provided on create.
+func (u *ArticleUpsertBulk) UpdateCreateIdempotencyKey() *ArticleUpsertBulk {
+	return u.Update(func(s *ArticleUpsert) {
+		s.UpdateCreateIdempotencyKey()
+	})
+}
+
+// ClearCreateIdempotencyKey clears the value of the "create_idempotency_key" field.
+func (u *ArticleUpsertBulk) ClearCreateIdempotencyKey() *ArticleUpsertBulk {
+	return u.Update(func(s *ArticleUpsert) {
+		s.ClearCreateIdempotencyKey()
+	})
+}
+
+// SetCreateRequestDigest sets the "create_request_digest" field.
+func (u *ArticleUpsertBulk) SetCreateRequestDigest(v string) *ArticleUpsertBulk {
+	return u.Update(func(s *ArticleUpsert) {
+		s.SetCreateRequestDigest(v)
+	})
+}
+
+// UpdateCreateRequestDigest sets the "create_request_digest" field to the value that was provided on create.
+func (u *ArticleUpsertBulk) UpdateCreateRequestDigest() *ArticleUpsertBulk {
+	return u.Update(func(s *ArticleUpsert) {
+		s.UpdateCreateRequestDigest()
+	})
+}
+
+// ClearCreateRequestDigest clears the value of the "create_request_digest" field.
+func (u *ArticleUpsertBulk) ClearCreateRequestDigest() *ArticleUpsertBulk {
+	return u.Update(func(s *ArticleUpsert) {
+		s.ClearCreateRequestDigest()
 	})
 }
 

--- a/ent/article_update.go
+++ b/ent/article_update.go
@@ -1025,11 +1025,6 @@ func (_u *ArticleUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *ArticleUpdate) check() error {
-	if v, ok := _u.mutation.Title(); ok {
-		if err := article.TitleValidator(v); err != nil {
-			return &ValidationError{Name: "title", err: fmt.Errorf(`ent: validator failed for field "Article.title": %w`, err)}
-		}
-	}
 	if v, ok := _u.mutation.Status(); ok {
 		if err := article.StatusValidator(v); err != nil {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "Article.status": %w`, err)}
@@ -2549,11 +2544,6 @@ func (_u *ArticleUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *ArticleUpdateOne) check() error {
-	if v, ok := _u.mutation.Title(); ok {
-		if err := article.TitleValidator(v); err != nil {
-			return &ValidationError{Name: "title", err: fmt.Errorf(`ent: validator failed for field "Article.title": %w`, err)}
-		}
-	}
 	if v, ok := _u.mutation.Status(); ok {
 		if err := article.StatusValidator(v); err != nil {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "Article.status": %w`, err)}

--- a/ent/article_update.go
+++ b/ent/article_update.go
@@ -118,6 +118,46 @@ func (_u *ArticleUpdate) SetNillableTitle(v *string) *ArticleUpdate {
 	return _u
 }
 
+// SetCreateIdempotencyKey sets the "create_idempotency_key" field.
+func (_u *ArticleUpdate) SetCreateIdempotencyKey(v string) *ArticleUpdate {
+	_u.mutation.SetCreateIdempotencyKey(v)
+	return _u
+}
+
+// SetNillableCreateIdempotencyKey sets the "create_idempotency_key" field if the given value is not nil.
+func (_u *ArticleUpdate) SetNillableCreateIdempotencyKey(v *string) *ArticleUpdate {
+	if v != nil {
+		_u.SetCreateIdempotencyKey(*v)
+	}
+	return _u
+}
+
+// ClearCreateIdempotencyKey clears the value of the "create_idempotency_key" field.
+func (_u *ArticleUpdate) ClearCreateIdempotencyKey() *ArticleUpdate {
+	_u.mutation.ClearCreateIdempotencyKey()
+	return _u
+}
+
+// SetCreateRequestDigest sets the "create_request_digest" field.
+func (_u *ArticleUpdate) SetCreateRequestDigest(v string) *ArticleUpdate {
+	_u.mutation.SetCreateRequestDigest(v)
+	return _u
+}
+
+// SetNillableCreateRequestDigest sets the "create_request_digest" field if the given value is not nil.
+func (_u *ArticleUpdate) SetNillableCreateRequestDigest(v *string) *ArticleUpdate {
+	if v != nil {
+		_u.SetCreateRequestDigest(*v)
+	}
+	return _u
+}
+
+// ClearCreateRequestDigest clears the value of the "create_request_digest" field.
+func (_u *ArticleUpdate) ClearCreateRequestDigest() *ArticleUpdate {
+	_u.mutation.ClearCreateRequestDigest()
+	return _u
+}
+
 // SetContentMd sets the "content_md" field.
 func (_u *ArticleUpdate) SetContentMd(v string) *ArticleUpdate {
 	_u.mutation.SetContentMd(v)
@@ -1025,6 +1065,16 @@ func (_u *ArticleUpdate) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *ArticleUpdate) check() error {
+	if v, ok := _u.mutation.CreateIdempotencyKey(); ok {
+		if err := article.CreateIdempotencyKeyValidator(v); err != nil {
+			return &ValidationError{Name: "create_idempotency_key", err: fmt.Errorf(`ent: validator failed for field "Article.create_idempotency_key": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.CreateRequestDigest(); ok {
+		if err := article.CreateRequestDigestValidator(v); err != nil {
+			return &ValidationError{Name: "create_request_digest", err: fmt.Errorf(`ent: validator failed for field "Article.create_request_digest": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Status(); ok {
 		if err := article.StatusValidator(v); err != nil {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "Article.status": %w`, err)}
@@ -1106,6 +1156,18 @@ func (_u *ArticleUpdate) sqlSave(ctx context.Context) (_node int, err error) {
 	}
 	if value, ok := _u.mutation.Title(); ok {
 		_spec.SetField(article.FieldTitle, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.CreateIdempotencyKey(); ok {
+		_spec.SetField(article.FieldCreateIdempotencyKey, field.TypeString, value)
+	}
+	if _u.mutation.CreateIdempotencyKeyCleared() {
+		_spec.ClearField(article.FieldCreateIdempotencyKey, field.TypeString)
+	}
+	if value, ok := _u.mutation.CreateRequestDigest(); ok {
+		_spec.SetField(article.FieldCreateRequestDigest, field.TypeString, value)
+	}
+	if _u.mutation.CreateRequestDigestCleared() {
+		_spec.ClearField(article.FieldCreateRequestDigest, field.TypeString)
 	}
 	if value, ok := _u.mutation.ContentMd(); ok {
 		_spec.SetField(article.FieldContentMd, field.TypeString, value)
@@ -1621,6 +1683,46 @@ func (_u *ArticleUpdateOne) SetNillableTitle(v *string) *ArticleUpdateOne {
 	if v != nil {
 		_u.SetTitle(*v)
 	}
+	return _u
+}
+
+// SetCreateIdempotencyKey sets the "create_idempotency_key" field.
+func (_u *ArticleUpdateOne) SetCreateIdempotencyKey(v string) *ArticleUpdateOne {
+	_u.mutation.SetCreateIdempotencyKey(v)
+	return _u
+}
+
+// SetNillableCreateIdempotencyKey sets the "create_idempotency_key" field if the given value is not nil.
+func (_u *ArticleUpdateOne) SetNillableCreateIdempotencyKey(v *string) *ArticleUpdateOne {
+	if v != nil {
+		_u.SetCreateIdempotencyKey(*v)
+	}
+	return _u
+}
+
+// ClearCreateIdempotencyKey clears the value of the "create_idempotency_key" field.
+func (_u *ArticleUpdateOne) ClearCreateIdempotencyKey() *ArticleUpdateOne {
+	_u.mutation.ClearCreateIdempotencyKey()
+	return _u
+}
+
+// SetCreateRequestDigest sets the "create_request_digest" field.
+func (_u *ArticleUpdateOne) SetCreateRequestDigest(v string) *ArticleUpdateOne {
+	_u.mutation.SetCreateRequestDigest(v)
+	return _u
+}
+
+// SetNillableCreateRequestDigest sets the "create_request_digest" field if the given value is not nil.
+func (_u *ArticleUpdateOne) SetNillableCreateRequestDigest(v *string) *ArticleUpdateOne {
+	if v != nil {
+		_u.SetCreateRequestDigest(*v)
+	}
+	return _u
+}
+
+// ClearCreateRequestDigest clears the value of the "create_request_digest" field.
+func (_u *ArticleUpdateOne) ClearCreateRequestDigest() *ArticleUpdateOne {
+	_u.mutation.ClearCreateRequestDigest()
 	return _u
 }
 
@@ -2544,6 +2646,16 @@ func (_u *ArticleUpdateOne) ExecX(ctx context.Context) {
 
 // check runs all checks and user-defined validators on the builder.
 func (_u *ArticleUpdateOne) check() error {
+	if v, ok := _u.mutation.CreateIdempotencyKey(); ok {
+		if err := article.CreateIdempotencyKeyValidator(v); err != nil {
+			return &ValidationError{Name: "create_idempotency_key", err: fmt.Errorf(`ent: validator failed for field "Article.create_idempotency_key": %w`, err)}
+		}
+	}
+	if v, ok := _u.mutation.CreateRequestDigest(); ok {
+		if err := article.CreateRequestDigestValidator(v); err != nil {
+			return &ValidationError{Name: "create_request_digest", err: fmt.Errorf(`ent: validator failed for field "Article.create_request_digest": %w`, err)}
+		}
+	}
 	if v, ok := _u.mutation.Status(); ok {
 		if err := article.StatusValidator(v); err != nil {
 			return &ValidationError{Name: "status", err: fmt.Errorf(`ent: validator failed for field "Article.status": %w`, err)}
@@ -2642,6 +2754,18 @@ func (_u *ArticleUpdateOne) sqlSave(ctx context.Context) (_node *Article, err er
 	}
 	if value, ok := _u.mutation.Title(); ok {
 		_spec.SetField(article.FieldTitle, field.TypeString, value)
+	}
+	if value, ok := _u.mutation.CreateIdempotencyKey(); ok {
+		_spec.SetField(article.FieldCreateIdempotencyKey, field.TypeString, value)
+	}
+	if _u.mutation.CreateIdempotencyKeyCleared() {
+		_spec.ClearField(article.FieldCreateIdempotencyKey, field.TypeString)
+	}
+	if value, ok := _u.mutation.CreateRequestDigest(); ok {
+		_spec.SetField(article.FieldCreateRequestDigest, field.TypeString, value)
+	}
+	if _u.mutation.CreateRequestDigestCleared() {
+		_spec.ClearField(article.FieldCreateRequestDigest, field.TypeString)
 	}
 	if value, ok := _u.mutation.ContentMd(); ok {
 		_spec.SetField(article.FieldContentMd, field.TypeString, value)

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -71,7 +71,7 @@ var (
 		{Name: "owner_id", Type: field.TypeUint, Comment: "文章作者ID，关联到users表", Default: 1},
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
-		{Name: "title", Type: field.TypeString, Comment: "文章标题"},
+		{Name: "title", Type: field.TypeString, Comment: "文章标题", Default: ""},
 		{Name: "content_md", Type: field.TypeString, Nullable: true, Size: 2147483647, Comment: "文章的 Markdown 原文"},
 		{Name: "content_html", Type: field.TypeString, Nullable: true, Size: 2147483647, Comment: "由 content_md 解析和净化后的 HTML"},
 		{Name: "cover_url", Type: field.TypeString, Nullable: true, Comment: "封面图URL"},

--- a/ent/migrate/schema.go
+++ b/ent/migrate/schema.go
@@ -72,6 +72,8 @@ var (
 		{Name: "created_at", Type: field.TypeTime},
 		{Name: "updated_at", Type: field.TypeTime},
 		{Name: "title", Type: field.TypeString, Comment: "文章标题", Default: ""},
+		{Name: "create_idempotency_key", Type: field.TypeString, Unique: true, Nullable: true, Size: 64, Comment: "创建文章使用的内部幂等键摘要"},
+		{Name: "create_request_digest", Type: field.TypeString, Nullable: true, Size: 64, Comment: "创建文章请求的内部摘要"},
 		{Name: "content_md", Type: field.TypeString, Nullable: true, Size: 2147483647, Comment: "文章的 Markdown 原文"},
 		{Name: "content_html", Type: field.TypeString, Nullable: true, Size: 2147483647, Comment: "由 content_md 解析和净化后的 HTML"},
 		{Name: "cover_url", Type: field.TypeString, Nullable: true, Comment: "封面图URL"},
@@ -121,7 +123,7 @@ var (
 		ForeignKeys: []*schema.ForeignKey{
 			{
 				Symbol:     "articles_doc_series_articles",
-				Columns:    []*schema.Column{ArticlesColumns[44]},
+				Columns:    []*schema.Column{ArticlesColumns[46]},
 				RefColumns: []*schema.Column{DocSeriesColumns[0]},
 				OnDelete:   schema.SetNull,
 			},
@@ -130,27 +132,27 @@ var (
 			{
 				Name:    "article_deleted_at_status_is_takedown_review_status_show_on_home",
 				Unique:  false,
-				Columns: []*schema.Column{ArticlesColumns[1], ArticlesColumns[9], ArticlesColumns[33], ArticlesColumns[29], ArticlesColumns[16]},
+				Columns: []*schema.Column{ArticlesColumns[1], ArticlesColumns[11], ArticlesColumns[35], ArticlesColumns[31], ArticlesColumns[18]},
 			},
 			{
 				Name:    "article_deleted_at_status_pin_sort_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{ArticlesColumns[1], ArticlesColumns[9], ArticlesColumns[18], ArticlesColumns[3]},
+				Columns: []*schema.Column{ArticlesColumns[1], ArticlesColumns[11], ArticlesColumns[20], ArticlesColumns[3]},
 			},
 			{
 				Name:    "article_deleted_at_status_created_at",
 				Unique:  false,
-				Columns: []*schema.Column{ArticlesColumns[1], ArticlesColumns[9], ArticlesColumns[3]},
+				Columns: []*schema.Column{ArticlesColumns[1], ArticlesColumns[11], ArticlesColumns[3]},
 			},
 			{
 				Name:    "article_deleted_at_is_doc_doc_series_id_doc_sort",
 				Unique:  false,
-				Columns: []*schema.Column{ArticlesColumns[1], ArticlesColumns[39], ArticlesColumns[44], ArticlesColumns[40]},
+				Columns: []*schema.Column{ArticlesColumns[1], ArticlesColumns[41], ArticlesColumns[46], ArticlesColumns[42]},
 			},
 			{
 				Name:    "article_deleted_at_owner_id_status",
 				Unique:  false,
-				Columns: []*schema.Column{ArticlesColumns[1], ArticlesColumns[2], ArticlesColumns[9]},
+				Columns: []*schema.Column{ArticlesColumns[1], ArticlesColumns[2], ArticlesColumns[11]},
 			},
 		},
 	}

--- a/ent/mutation.go
+++ b/ent/mutation.go
@@ -2772,6 +2772,8 @@ type ArticleMutation struct {
 	created_at              *time.Time
 	updated_at              *time.Time
 	title                   *string
+	create_idempotency_key  *string
+	create_request_digest   *string
 	content_md              *string
 	content_html            *string
 	cover_url               *string
@@ -3154,6 +3156,104 @@ func (m *ArticleMutation) OldTitle(ctx context.Context) (v string, err error) {
 // ResetTitle resets all changes to the "title" field.
 func (m *ArticleMutation) ResetTitle() {
 	m.title = nil
+}
+
+// SetCreateIdempotencyKey sets the "create_idempotency_key" field.
+func (m *ArticleMutation) SetCreateIdempotencyKey(s string) {
+	m.create_idempotency_key = &s
+}
+
+// CreateIdempotencyKey returns the value of the "create_idempotency_key" field in the mutation.
+func (m *ArticleMutation) CreateIdempotencyKey() (r string, exists bool) {
+	v := m.create_idempotency_key
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCreateIdempotencyKey returns the old "create_idempotency_key" field's value of the Article entity.
+// If the Article object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ArticleMutation) OldCreateIdempotencyKey(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCreateIdempotencyKey is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCreateIdempotencyKey requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCreateIdempotencyKey: %w", err)
+	}
+	return oldValue.CreateIdempotencyKey, nil
+}
+
+// ClearCreateIdempotencyKey clears the value of the "create_idempotency_key" field.
+func (m *ArticleMutation) ClearCreateIdempotencyKey() {
+	m.create_idempotency_key = nil
+	m.clearedFields[article.FieldCreateIdempotencyKey] = struct{}{}
+}
+
+// CreateIdempotencyKeyCleared returns if the "create_idempotency_key" field was cleared in this mutation.
+func (m *ArticleMutation) CreateIdempotencyKeyCleared() bool {
+	_, ok := m.clearedFields[article.FieldCreateIdempotencyKey]
+	return ok
+}
+
+// ResetCreateIdempotencyKey resets all changes to the "create_idempotency_key" field.
+func (m *ArticleMutation) ResetCreateIdempotencyKey() {
+	m.create_idempotency_key = nil
+	delete(m.clearedFields, article.FieldCreateIdempotencyKey)
+}
+
+// SetCreateRequestDigest sets the "create_request_digest" field.
+func (m *ArticleMutation) SetCreateRequestDigest(s string) {
+	m.create_request_digest = &s
+}
+
+// CreateRequestDigest returns the value of the "create_request_digest" field in the mutation.
+func (m *ArticleMutation) CreateRequestDigest() (r string, exists bool) {
+	v := m.create_request_digest
+	if v == nil {
+		return
+	}
+	return *v, true
+}
+
+// OldCreateRequestDigest returns the old "create_request_digest" field's value of the Article entity.
+// If the Article object wasn't provided to the builder, the object is fetched from the database.
+// An error is returned if the mutation operation is not UpdateOne, or the database query fails.
+func (m *ArticleMutation) OldCreateRequestDigest(ctx context.Context) (v *string, err error) {
+	if !m.op.Is(OpUpdateOne) {
+		return v, errors.New("OldCreateRequestDigest is only allowed on UpdateOne operations")
+	}
+	if m.id == nil || m.oldValue == nil {
+		return v, errors.New("OldCreateRequestDigest requires an ID field in the mutation")
+	}
+	oldValue, err := m.oldValue(ctx)
+	if err != nil {
+		return v, fmt.Errorf("querying old value for OldCreateRequestDigest: %w", err)
+	}
+	return oldValue.CreateRequestDigest, nil
+}
+
+// ClearCreateRequestDigest clears the value of the "create_request_digest" field.
+func (m *ArticleMutation) ClearCreateRequestDigest() {
+	m.create_request_digest = nil
+	m.clearedFields[article.FieldCreateRequestDigest] = struct{}{}
+}
+
+// CreateRequestDigestCleared returns if the "create_request_digest" field was cleared in this mutation.
+func (m *ArticleMutation) CreateRequestDigestCleared() bool {
+	_, ok := m.clearedFields[article.FieldCreateRequestDigest]
+	return ok
+}
+
+// ResetCreateRequestDigest resets all changes to the "create_request_digest" field.
+func (m *ArticleMutation) ResetCreateRequestDigest() {
+	m.create_request_digest = nil
+	delete(m.clearedFields, article.FieldCreateRequestDigest)
 }
 
 // SetContentMd sets the "content_md" field.
@@ -5288,7 +5388,7 @@ func (m *ArticleMutation) Type() string {
 // order to get all numeric fields that were incremented/decremented, call
 // AddedFields().
 func (m *ArticleMutation) Fields() []string {
-	fields := make([]string, 0, 44)
+	fields := make([]string, 0, 46)
 	if m.deleted_at != nil {
 		fields = append(fields, article.FieldDeletedAt)
 	}
@@ -5303,6 +5403,12 @@ func (m *ArticleMutation) Fields() []string {
 	}
 	if m.title != nil {
 		fields = append(fields, article.FieldTitle)
+	}
+	if m.create_idempotency_key != nil {
+		fields = append(fields, article.FieldCreateIdempotencyKey)
+	}
+	if m.create_request_digest != nil {
+		fields = append(fields, article.FieldCreateRequestDigest)
 	}
 	if m.content_md != nil {
 		fields = append(fields, article.FieldContentMd)
@@ -5439,6 +5545,10 @@ func (m *ArticleMutation) Field(name string) (ent.Value, bool) {
 		return m.UpdatedAt()
 	case article.FieldTitle:
 		return m.Title()
+	case article.FieldCreateIdempotencyKey:
+		return m.CreateIdempotencyKey()
+	case article.FieldCreateRequestDigest:
+		return m.CreateRequestDigest()
 	case article.FieldContentMd:
 		return m.ContentMd()
 	case article.FieldContentHTML:
@@ -5536,6 +5646,10 @@ func (m *ArticleMutation) OldField(ctx context.Context, name string) (ent.Value,
 		return m.OldUpdatedAt(ctx)
 	case article.FieldTitle:
 		return m.OldTitle(ctx)
+	case article.FieldCreateIdempotencyKey:
+		return m.OldCreateIdempotencyKey(ctx)
+	case article.FieldCreateRequestDigest:
+		return m.OldCreateRequestDigest(ctx)
 	case article.FieldContentMd:
 		return m.OldContentMd(ctx)
 	case article.FieldContentHTML:
@@ -5657,6 +5771,20 @@ func (m *ArticleMutation) SetField(name string, value ent.Value) error {
 			return fmt.Errorf("unexpected type %T for field %s", value, name)
 		}
 		m.SetTitle(v)
+		return nil
+	case article.FieldCreateIdempotencyKey:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCreateIdempotencyKey(v)
+		return nil
+	case article.FieldCreateRequestDigest:
+		v, ok := value.(string)
+		if !ok {
+			return fmt.Errorf("unexpected type %T for field %s", value, name)
+		}
+		m.SetCreateRequestDigest(v)
 		return nil
 	case article.FieldContentMd:
 		v, ok := value.(string)
@@ -6075,6 +6203,12 @@ func (m *ArticleMutation) ClearedFields() []string {
 	if m.FieldCleared(article.FieldDeletedAt) {
 		fields = append(fields, article.FieldDeletedAt)
 	}
+	if m.FieldCleared(article.FieldCreateIdempotencyKey) {
+		fields = append(fields, article.FieldCreateIdempotencyKey)
+	}
+	if m.FieldCleared(article.FieldCreateRequestDigest) {
+		fields = append(fields, article.FieldCreateRequestDigest)
+	}
 	if m.FieldCleared(article.FieldContentMd) {
 		fields = append(fields, article.FieldContentMd)
 	}
@@ -6154,6 +6288,12 @@ func (m *ArticleMutation) ClearField(name string) error {
 	switch name {
 	case article.FieldDeletedAt:
 		m.ClearDeletedAt()
+		return nil
+	case article.FieldCreateIdempotencyKey:
+		m.ClearCreateIdempotencyKey()
+		return nil
+	case article.FieldCreateRequestDigest:
+		m.ClearCreateRequestDigest()
 		return nil
 	case article.FieldContentMd:
 		m.ClearContentMd()
@@ -6240,6 +6380,12 @@ func (m *ArticleMutation) ResetField(name string) error {
 		return nil
 	case article.FieldTitle:
 		m.ResetTitle()
+		return nil
+	case article.FieldCreateIdempotencyKey:
+		m.ResetCreateIdempotencyKey()
+		return nil
+	case article.FieldCreateRequestDigest:
+		m.ResetCreateRequestDigest()
 		return nil
 	case article.FieldContentMd:
 		m.ResetContentMd()

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -160,8 +160,8 @@ func init() {
 	article.DefaultUpdatedAt = articleDescUpdatedAt.Default.(func() time.Time)
 	// articleDescTitle is the schema descriptor for title field.
 	articleDescTitle := articleFields[4].Descriptor()
-	// article.TitleValidator is a validator for the "title" field. It is called by the builders before save.
-	article.TitleValidator = articleDescTitle.Validators[0].(func(string) error)
+	// article.DefaultTitle holds the default value on creation for the title field.
+	article.DefaultTitle = articleDescTitle.Default.(string)
 	// articleDescViewCount is the schema descriptor for view_count field.
 	articleDescViewCount := articleFields[9].Descriptor()
 	// article.DefaultViewCount holds the default value on creation for the view_count field.
@@ -1251,6 +1251,6 @@ func init() {
 }
 
 const (
-	Version = "v0.14.6"                                         // Version of ent codegen.
-	Sum     = "h1:/f2696BpwuWAEEG6PVGWflg6+Inrpq4pRWuNlWz/Skk=" // Sum of ent codegen.
+	Version = "v0.14.5"                                         // Version of ent codegen.
+	Sum     = "h1:Rj2WOYJtCkWyFo6a+5wB3EfBRP0rnx1fMk6gGA0UUe4=" // Sum of ent codegen.
 )

--- a/ent/runtime/runtime.go
+++ b/ent/runtime/runtime.go
@@ -162,84 +162,92 @@ func init() {
 	articleDescTitle := articleFields[4].Descriptor()
 	// article.DefaultTitle holds the default value on creation for the title field.
 	article.DefaultTitle = articleDescTitle.Default.(string)
+	// articleDescCreateIdempotencyKey is the schema descriptor for create_idempotency_key field.
+	articleDescCreateIdempotencyKey := articleFields[5].Descriptor()
+	// article.CreateIdempotencyKeyValidator is a validator for the "create_idempotency_key" field. It is called by the builders before save.
+	article.CreateIdempotencyKeyValidator = articleDescCreateIdempotencyKey.Validators[0].(func(string) error)
+	// articleDescCreateRequestDigest is the schema descriptor for create_request_digest field.
+	articleDescCreateRequestDigest := articleFields[6].Descriptor()
+	// article.CreateRequestDigestValidator is a validator for the "create_request_digest" field. It is called by the builders before save.
+	article.CreateRequestDigestValidator = articleDescCreateRequestDigest.Validators[0].(func(string) error)
 	// articleDescViewCount is the schema descriptor for view_count field.
-	articleDescViewCount := articleFields[9].Descriptor()
+	articleDescViewCount := articleFields[11].Descriptor()
 	// article.DefaultViewCount holds the default value on creation for the view_count field.
 	article.DefaultViewCount = articleDescViewCount.Default.(int)
 	// article.ViewCountValidator is a validator for the "view_count" field. It is called by the builders before save.
 	article.ViewCountValidator = articleDescViewCount.Validators[0].(func(int) error)
 	// articleDescWordCount is the schema descriptor for word_count field.
-	articleDescWordCount := articleFields[10].Descriptor()
+	articleDescWordCount := articleFields[12].Descriptor()
 	// article.DefaultWordCount holds the default value on creation for the word_count field.
 	article.DefaultWordCount = articleDescWordCount.Default.(int)
 	// article.WordCountValidator is a validator for the "word_count" field. It is called by the builders before save.
 	article.WordCountValidator = articleDescWordCount.Validators[0].(func(int) error)
 	// articleDescReadingTime is the schema descriptor for reading_time field.
-	articleDescReadingTime := articleFields[11].Descriptor()
+	articleDescReadingTime := articleFields[13].Descriptor()
 	// article.DefaultReadingTime holds the default value on creation for the reading_time field.
 	article.DefaultReadingTime = articleDescReadingTime.Default.(int)
 	// article.ReadingTimeValidator is a validator for the "reading_time" field. It is called by the builders before save.
 	article.ReadingTimeValidator = articleDescReadingTime.Validators[0].(func(int) error)
 	// articleDescPrimaryColor is the schema descriptor for primary_color field.
-	articleDescPrimaryColor := articleFields[13].Descriptor()
+	articleDescPrimaryColor := articleFields[15].Descriptor()
 	// article.DefaultPrimaryColor holds the default value on creation for the primary_color field.
 	article.DefaultPrimaryColor = articleDescPrimaryColor.Default.(string)
 	// articleDescIsPrimaryColorManual is the schema descriptor for is_primary_color_manual field.
-	articleDescIsPrimaryColorManual := articleFields[14].Descriptor()
+	articleDescIsPrimaryColorManual := articleFields[16].Descriptor()
 	// article.DefaultIsPrimaryColorManual holds the default value on creation for the is_primary_color_manual field.
 	article.DefaultIsPrimaryColorManual = articleDescIsPrimaryColorManual.Default.(bool)
 	// articleDescShowOnHome is the schema descriptor for show_on_home field.
-	articleDescShowOnHome := articleFields[15].Descriptor()
+	articleDescShowOnHome := articleFields[17].Descriptor()
 	// article.DefaultShowOnHome holds the default value on creation for the show_on_home field.
 	article.DefaultShowOnHome = articleDescShowOnHome.Default.(bool)
 	// articleDescHomeSort is the schema descriptor for home_sort field.
-	articleDescHomeSort := articleFields[16].Descriptor()
+	articleDescHomeSort := articleFields[18].Descriptor()
 	// article.DefaultHomeSort holds the default value on creation for the home_sort field.
 	article.DefaultHomeSort = articleDescHomeSort.Default.(int)
 	// article.HomeSortValidator is a validator for the "home_sort" field. It is called by the builders before save.
 	article.HomeSortValidator = articleDescHomeSort.Validators[0].(func(int) error)
 	// articleDescPinSort is the schema descriptor for pin_sort field.
-	articleDescPinSort := articleFields[17].Descriptor()
+	articleDescPinSort := articleFields[19].Descriptor()
 	// article.DefaultPinSort holds the default value on creation for the pin_sort field.
 	article.DefaultPinSort = articleDescPinSort.Default.(int)
 	// article.PinSortValidator is a validator for the "pin_sort" field. It is called by the builders before save.
 	article.PinSortValidator = articleDescPinSort.Validators[0].(func(int) error)
 	// articleDescCopyright is the schema descriptor for copyright field.
-	articleDescCopyright := articleFields[21].Descriptor()
+	articleDescCopyright := articleFields[23].Descriptor()
 	// article.DefaultCopyright holds the default value on creation for the copyright field.
 	article.DefaultCopyright = articleDescCopyright.Default.(bool)
 	// articleDescIsReprint is the schema descriptor for is_reprint field.
-	articleDescIsReprint := articleFields[22].Descriptor()
+	articleDescIsReprint := articleFields[24].Descriptor()
 	// article.DefaultIsReprint holds the default value on creation for the is_reprint field.
 	article.DefaultIsReprint = articleDescIsReprint.Default.(bool)
 	// articleDescIsTakedown is the schema descriptor for is_takedown field.
-	articleDescIsTakedown := articleFields[32].Descriptor()
+	articleDescIsTakedown := articleFields[34].Descriptor()
 	// article.DefaultIsTakedown holds the default value on creation for the is_takedown field.
 	article.DefaultIsTakedown = articleDescIsTakedown.Default.(bool)
 	// articleDescExcludeFromMembership is the schema descriptor for exclude_from_membership field.
-	articleDescExcludeFromMembership := articleFields[37].Descriptor()
+	articleDescExcludeFromMembership := articleFields[39].Descriptor()
 	// article.DefaultExcludeFromMembership holds the default value on creation for the exclude_from_membership field.
 	article.DefaultExcludeFromMembership = articleDescExcludeFromMembership.Default.(bool)
 	// articleDescIsDoc is the schema descriptor for is_doc field.
-	articleDescIsDoc := articleFields[38].Descriptor()
+	articleDescIsDoc := articleFields[40].Descriptor()
 	// article.DefaultIsDoc holds the default value on creation for the is_doc field.
 	article.DefaultIsDoc = articleDescIsDoc.Default.(bool)
 	// articleDescDocSort is the schema descriptor for doc_sort field.
-	articleDescDocSort := articleFields[40].Descriptor()
+	articleDescDocSort := articleFields[42].Descriptor()
 	// article.DefaultDocSort holds the default value on creation for the doc_sort field.
 	article.DefaultDocSort = articleDescDocSort.Default.(int)
 	// article.DocSortValidator is a validator for the "doc_sort" field. It is called by the builders before save.
 	article.DocSortValidator = articleDescDocSort.Validators[0].(func(int) error)
 	// articleDescShowRewardButton is the schema descriptor for show_reward_button field.
-	articleDescShowRewardButton := articleFields[41].Descriptor()
+	articleDescShowRewardButton := articleFields[43].Descriptor()
 	// article.DefaultShowRewardButton holds the default value on creation for the show_reward_button field.
 	article.DefaultShowRewardButton = articleDescShowRewardButton.Default.(bool)
 	// articleDescShowShareButton is the schema descriptor for show_share_button field.
-	articleDescShowShareButton := articleFields[42].Descriptor()
+	articleDescShowShareButton := articleFields[44].Descriptor()
 	// article.DefaultShowShareButton holds the default value on creation for the show_share_button field.
 	article.DefaultShowShareButton = articleDescShowShareButton.Default.(bool)
 	// articleDescShowSubscribeButton is the schema descriptor for show_subscribe_button field.
-	articleDescShowSubscribeButton := articleFields[43].Descriptor()
+	articleDescShowSubscribeButton := articleFields[45].Descriptor()
 	// article.DefaultShowSubscribeButton holds the default value on creation for the show_subscribe_button field.
 	article.DefaultShowSubscribeButton = articleDescShowSubscribeButton.Default.(bool)
 	articlehistoryFields := schema.ArticleHistory{}.Fields()

--- a/ent/schema/article.go
+++ b/ent/schema/article.go
@@ -53,6 +53,19 @@ func (Article) Fields() []ent.Field {
 		field.Time("created_at").Default(time.Now),
 		field.Time("updated_at").Default(time.Now),
 		field.String("title").Default("").Comment("文章标题"),
+		field.String("create_idempotency_key").
+			Comment("创建文章使用的内部幂等键摘要").
+			Optional().
+			Nillable().
+			Unique().
+			MaxLen(64).
+			Sensitive(),
+		field.String("create_request_digest").
+			Comment("创建文章请求的内部摘要").
+			Optional().
+			Nillable().
+			MaxLen(64).
+			Sensitive(),
 		field.Text("content_md").Comment("文章的 Markdown 原文").Optional(),
 		field.Text("content_html").Comment("由 content_md 解析和净化后的 HTML").Optional(),
 		field.String("cover_url").Comment("封面图URL").Optional(),

--- a/ent/schema/article.go
+++ b/ent/schema/article.go
@@ -52,7 +52,7 @@ func (Article) Fields() []ent.Field {
 			Default(1), // 默认值为管理员ID(1)
 		field.Time("created_at").Default(time.Now),
 		field.Time("updated_at").Default(time.Now),
-		field.String("title").Comment("文章标题").NotEmpty(),
+		field.String("title").Default("").Comment("文章标题"),
 		field.Text("content_md").Comment("文章的 Markdown 原文").Optional(),
 		field.Text("content_html").Comment("由 content_md 解析和净化后的 HTML").Optional(),
 		field.String("cover_url").Comment("封面图URL").Optional(),

--- a/go.mod
+++ b/go.mod
@@ -117,12 +117,14 @@ require (
 	github.com/hashicorp/go-plugin v1.7.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.18.1 // indirect
 	github.com/hashicorp/yamux v0.1.2 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/meilisearch/meilisearch-go v0.36.1 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -132,6 +134,7 @@ require (
 	github.com/ncruces/julianday v1.0.0 // indirect
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 // indirect
 	github.com/oklog/run v1.1.0 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/oliamb/cutter v0.2.2 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -142,6 +145,7 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tetratelabs/wazero v1.9.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,7 @@ github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5P
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/dave/jennifer v1.6.1/go.mod h1:nXbxhEmQfOZhWml3D1cDK5M1FLnMSozpbFN/m3RmGZc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -290,6 +291,8 @@ github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8
 github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -326,6 +329,8 @@ github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Ky
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.14.28 h1:ThEiQrnbtumT+QMknw63Befp/ce/nUPgBPMlRFEum7A=
 github.com/meilisearch/meilisearch-go v0.36.1 h1:mJTCJE5g7tRvaqKco6DfqOuJEjX+rRltDEnkEC02Y0M=
 github.com/meilisearch/meilisearch-go v0.36.1/go.mod h1:hWcR0MuWLSzHfbz9GGzIr3s9rnXLm1jqkmHkJPbUSvM=
@@ -356,6 +361,8 @@ github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646 h1:zYyBkD/k9seD2A7fsi6
 github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646/go.mod h1:jpp1/29i3P1S/RLdc7JQKbRpFeM1dOBd8T9ki5s+AY8=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
 github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/oliamb/cutter v0.2.2 h1:Lfwkya0HHNU1YLnGv2hTkzHfasrSMkgv4Dn+5rmlk3k=
 github.com/oliamb/cutter v0.2.2/go.mod h1:4BenG2/4GuRBDbVm/OPahDVqbrOemzpPiG5mi1iryBU=
 github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
@@ -383,6 +390,7 @@ github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6po
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/rs/dnscache v0.0.0-20230804202142-fc85eb664529/go.mod h1:qe5TWALJ8/a1Lqznoc5BDHpYX/8HU60Hm2AwRmqzxqA=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd h1:CmH9+J6ZSsIjUK3dcGsnCnO41eRBOnY12zwkn5qVwgc=
 github.com/rwcarlsen/goexif v0.0.0-20190401172101-9e8deecbddbd/go.mod h1:hPqNNc0+uJM6H+SuU8sEs5K5IQeKccPqeSjfgcKGgPk=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
@@ -394,6 +402,9 @@ github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=
 github.com/spf13/afero v1.15.0/go.mod h1:NC2ByUVxtQs4b3sIUphxK0NioZnmxgyCrfzeuq8lxMg=
 github.com/spf13/cast v1.10.0 h1:h2x0u2shc1QuLHfxi+cTJvs30+ZAHOGRic8uyGTDWxY=
 github.com/spf13/cast v1.10.0/go.mod h1:jNfB8QC9IA6ZuY2ZjDp0KtFO2LZZlg4S/7bzP6qqeHo=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.21.0 h1:x5S+0EU27Lbphp4UKm1C+1oQO+rKx36vfCoaVebLFSU=

--- a/internal/app/middleware/cors.go
+++ b/internal/app/middleware/cors.go
@@ -65,7 +65,7 @@ func Cors() gin.HandlerFunc {
 		c.Header("Access-Control-Allow-Origin", origin)
 		c.Header("Access-Control-Allow-Credentials", "true")
 		c.Header("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
-		c.Header("Access-Control-Allow-Headers", "Authorization, Content-Type, X-CSRF-Token, X-Requested-With, Range, Accept-Ranges, Content-Range, Content-Length, Content-Disposition")
+		c.Header("Access-Control-Allow-Headers", "Authorization, Content-Type, Idempotency-Key, X-CSRF-Token, X-Requested-With, Range, Accept-Ranges, Content-Range, Content-Length, Content-Disposition")
 		c.Header("Access-Control-Expose-Headers", "Authorization, Content-Range, Content-Length, Content-Disposition")
 
 		if c.Request.Method == http.MethodOptions {

--- a/internal/app/middleware/cors_idempotency_test.go
+++ b/internal/app/middleware/cors_idempotency_test.go
@@ -1,0 +1,40 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestCORSAllowsIdempotencyKeyHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	const origin = "https://editor.example.com"
+	SetCORSAllowedOrigins([]string{origin})
+	t.Cleanup(func() {
+		SetCORSAllowedOrigins(nil)
+	})
+
+	router := gin.New()
+	router.Use(Cors())
+	router.OPTIONS("/api/articles", func(c *gin.Context) {
+		c.Status(http.StatusNoContent)
+	})
+	request := httptest.NewRequest(http.MethodOptions, "/api/articles", nil)
+	request.Header.Set("Origin", origin)
+	request.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	request.Header.Set("Access-Control-Request-Headers", "content-type,idempotency-key")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+	allowedHeaders := strings.ToLower(recorder.Header().Get("Access-Control-Allow-Headers"))
+	if !strings.Contains(allowedHeaders, "idempotency-key") {
+		t.Fatalf("Access-Control-Allow-Headers = %q, want Idempotency-Key", allowedHeaders)
+	}
+}

--- a/internal/infra/persistence/ent/article_invariants_test.go
+++ b/internal/infra/persistence/ent/article_invariants_test.go
@@ -1,0 +1,291 @@
+package ent
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	entclient "github.com/anzhiyu-c/anheyu-app/ent"
+	"github.com/anzhiyu-c/anheyu-app/ent/article"
+	"github.com/anzhiyu-c/anheyu-app/ent/enttest"
+	"github.com/anzhiyu-c/anheyu-app/pkg/constant"
+	"github.com/anzhiyu-c/anheyu-app/pkg/domain/model"
+	"github.com/anzhiyu-c/anheyu-app/pkg/idgen"
+	_ "github.com/ncruces/go-sqlite3/driver"
+	_ "github.com/ncruces/go-sqlite3/embed"
+)
+
+func openArticleInvariantTestClient(t *testing.T, name string) *entclient.Client {
+	t.Helper()
+
+	if err := idgen.InitSqidsEncoderWithSeed(name); err != nil {
+		t.Fatalf("InitSqidsEncoderWithSeed() error = %v", err)
+	}
+	client := enttest.Open(t, "sqlite3", "file:"+name+"?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("client.Close() error = %v", err)
+		}
+	})
+	return client
+}
+
+func TestArticleRepositoryRejectsPublishedOrScheduledWithoutTitle(t *testing.T) {
+	client := openArticleInvariantTestClient(t, "article_title_status_check")
+	ctx := context.Background()
+	repo := NewArticleRepo(client, "sqlite3")
+
+	for _, status := range []article.Status{article.StatusPUBLISHED, article.StatusSCHEDULED} {
+		t.Run(string(status), func(t *testing.T) {
+			_, err := repo.Create(ctx, &model.CreateArticleParams{
+				Title:  " \t\n",
+				Status: string(status),
+			})
+			if !errors.Is(err, constant.ErrConflict) {
+				t.Fatalf("Create() error = %v, want ErrConflict", err)
+			}
+		})
+	}
+
+	if _, err := repo.Create(ctx, &model.CreateArticleParams{
+		Title:  "",
+		Status: string(article.StatusDRAFT),
+	}); err != nil {
+		t.Fatalf("Create() empty-title draft error = %v", err)
+	}
+	if _, err := repo.Create(ctx, &model.CreateArticleParams{
+		Title:  "",
+		Status: string(article.StatusARCHIVED),
+	}); err != nil {
+		t.Fatalf("Create() empty-title archived article error = %v", err)
+	}
+}
+
+func TestArticleRepositoryStoresAndFindsCreateIdempotencyMetadata(t *testing.T) {
+	client := openArticleInvariantTestClient(t, "article_create_idempotency")
+	ctx := context.Background()
+	repo := NewArticleRepo(client, "sqlite3")
+	const (
+		key    = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+		digest = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	)
+
+	created, err := repo.Create(ctx, &model.CreateArticleParams{
+		Title:                "",
+		Status:               string(article.StatusDRAFT),
+		CreateIdempotencyKey: key,
+		CreateRequestDigest:  digest,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	found, foundDigest, err := repo.FindByCreateIdempotencyKey(ctx, key)
+	if err != nil {
+		t.Fatalf("FindByCreateIdempotencyKey() error = %v", err)
+	}
+	if found == nil || found.ID != created.ID || foundDigest != digest {
+		t.Fatalf("found = (%v, %q), want article %q and digest %q", found, foundDigest, created.ID, digest)
+	}
+
+	_, err = repo.Create(ctx, &model.CreateArticleParams{
+		Status:               string(article.StatusDRAFT),
+		CreateIdempotencyKey: key,
+		CreateRequestDigest:  digest,
+	})
+	if !errors.Is(err, constant.ErrConflict) {
+		t.Fatalf("duplicate Create() error = %v, want ErrConflict", err)
+	}
+}
+
+func TestArticleRepositoryRejectsReplayAfterIdempotentResultWasDeleted(t *testing.T) {
+	client := openArticleInvariantTestClient(t, "article_deleted_idempotency")
+	ctx := context.Background()
+	repo := NewArticleRepo(client, "sqlite3")
+	const (
+		key    = "1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+		digest = "bbcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	)
+
+	created, err := repo.Create(ctx, &model.CreateArticleParams{
+		Status:               string(article.StatusDRAFT),
+		CreateIdempotencyKey: key,
+		CreateRequestDigest:  digest,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	dbID, _, err := idgen.DecodePublicID(created.ID)
+	if err != nil {
+		t.Fatalf("DecodePublicID() error = %v", err)
+	}
+	client.Article.UpdateOneID(dbID).SetDeletedAt(time.Now()).SaveX(ctx)
+
+	found, _, err := repo.FindByCreateIdempotencyKey(ctx, key)
+	if !errors.Is(err, constant.ErrConflict) {
+		t.Fatalf("FindByCreateIdempotencyKey() error = %v, want ErrConflict", err)
+	}
+	if found != nil {
+		t.Fatalf("FindByCreateIdempotencyKey() article = %v, want nil", found)
+	}
+}
+
+func TestArticleRepositoryGetByIDMapsMissingArticleToErrNotFound(t *testing.T) {
+	client := openArticleInvariantTestClient(t, "article_get_missing")
+	ctx := context.Background()
+	repo := NewArticleRepo(client, "sqlite3")
+	publicID, err := idgen.GeneratePublicID(999, idgen.EntityTypeArticle)
+	if err != nil {
+		t.Fatalf("GeneratePublicID() error = %v", err)
+	}
+
+	_, err = repo.GetByID(ctx, publicID)
+	if !errors.Is(err, constant.ErrNotFound) {
+		t.Fatalf("GetByID() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestArticleDatabasePreventsPartialUpdatesFromFormingInvalidPublicState(t *testing.T) {
+	client := openArticleInvariantTestClient(t, "article_partial_update_check")
+	ctx := context.Background()
+
+	entity := client.Article.Create().
+		SetTitle("Original").
+		SetStatus(article.StatusDRAFT).
+		SaveX(ctx)
+	publicID, err := idgen.GeneratePublicID(entity.ID, idgen.EntityTypeArticle)
+	if err != nil {
+		t.Fatalf("GeneratePublicID() error = %v", err)
+	}
+	repo := NewArticleRepo(client, "sqlite3")
+
+	blankTitle := "   "
+	if _, err := repo.Update(ctx, publicID, &model.UpdateArticleRequest{Title: &blankTitle}, nil); err != nil {
+		t.Fatalf("Update(title) error = %v", err)
+	}
+
+	published := string(article.StatusPUBLISHED)
+	if _, err := repo.Update(ctx, publicID, &model.UpdateArticleRequest{Status: &published}, nil); !errors.Is(err, constant.ErrConflict) {
+		t.Fatalf("Update(status) error = %v, want ErrConflict", err)
+	}
+
+	got := client.Article.GetX(ctx, entity.ID)
+	if got.Status != article.StatusDRAFT || got.Title != blankTitle {
+		t.Fatalf("stored article = (%q, %q), want (%q, %q)", got.Title, got.Status, blankTitle, article.StatusDRAFT)
+	}
+}
+
+func TestArticlePartialStatusUpdateDoesNotOverwriteConcurrentTitle(t *testing.T) {
+	client := openArticleInvariantTestClient(t, "article_partial_update_preserves_title")
+	ctx := context.Background()
+
+	entity := client.Article.Create().
+		SetTitle("Original").
+		SetStatus(article.StatusDRAFT).
+		SaveX(ctx)
+	publicID, err := idgen.GeneratePublicID(entity.ID, idgen.EntityTypeArticle)
+	if err != nil {
+		t.Fatalf("GeneratePublicID() error = %v", err)
+	}
+	repo := NewArticleRepo(client, "sqlite3")
+
+	newTitle := "New title"
+	if _, err := repo.Update(ctx, publicID, &model.UpdateArticleRequest{Title: &newTitle}, nil); err != nil {
+		t.Fatalf("Update(title) error = %v", err)
+	}
+	published := string(article.StatusPUBLISHED)
+	if _, err := repo.Update(ctx, publicID, &model.UpdateArticleRequest{Status: &published}, nil); err != nil {
+		t.Fatalf("Update(status) error = %v", err)
+	}
+
+	got := client.Article.GetX(ctx, entity.ID)
+	if got.Title != newTitle || got.Status != article.StatusPUBLISHED {
+		t.Fatalf("stored article = (%q, %q), want (%q, %q)", got.Title, got.Status, newTitle, article.StatusPUBLISHED)
+	}
+}
+
+func TestArticleRepositoryUsesUnicodeWhitespaceValidationForStatusGuard(t *testing.T) {
+	client := openArticleInvariantTestClient(t, "article_unicode_whitespace_guard")
+	ctx := context.Background()
+	entity := client.Article.Create().
+		SetTitle("\t\n").
+		SetStatus(article.StatusDRAFT).
+		SaveX(ctx)
+	publicID, err := idgen.GeneratePublicID(entity.ID, idgen.EntityTypeArticle)
+	if err != nil {
+		t.Fatalf("GeneratePublicID() error = %v", err)
+	}
+	repo := NewArticleRepo(client, "sqlite3")
+	published := string(article.StatusPUBLISHED)
+
+	_, err = repo.Update(ctx, publicID, &model.UpdateArticleRequest{Status: &published}, nil)
+	if !errors.Is(err, constant.ErrConflict) {
+		t.Fatalf("Update(status) error = %v, want ErrConflict", err)
+	}
+}
+
+func TestArticleInvariantGuardDistinguishesMissingArticle(t *testing.T) {
+	client := openArticleInvariantTestClient(t, "article_invariant_missing")
+	ctx := context.Background()
+	publicID, err := idgen.GeneratePublicID(999, idgen.EntityTypeArticle)
+	if err != nil {
+		t.Fatalf("GeneratePublicID() error = %v", err)
+	}
+	repo := NewArticleRepo(client, "sqlite3")
+	published := string(article.StatusPUBLISHED)
+
+	_, err = repo.Update(ctx, publicID, &model.UpdateArticleRequest{Status: &published}, nil)
+	if !errors.Is(err, constant.ErrNotFound) {
+		t.Fatalf("Update(status) error = %v, want ErrNotFound", err)
+	}
+	if errors.Is(err, constant.ErrConflict) {
+		t.Fatalf("Update(status) error = %v, must not report a missing article as ErrConflict", err)
+	}
+}
+
+func TestPublishScheduledArticleRejectsLegacyBlankTitle(t *testing.T) {
+	client := openArticleInvariantTestClient(t, "article_scheduled_publish_guard")
+	ctx := context.Background()
+	scheduledAt := time.Now().Add(-time.Minute)
+
+	entity := client.Article.Create().
+		SetTitle("  ").
+		SetStatus(article.StatusSCHEDULED).
+		SetScheduledAt(scheduledAt).
+		SaveX(ctx)
+	repo := NewArticleRepo(client, "sqlite3")
+
+	err := repo.PublishScheduledArticle(ctx, entity.ID)
+	if !errors.Is(err, constant.ErrConflict) {
+		t.Fatalf("PublishScheduledArticle() error = %v, want ErrConflict", err)
+	}
+
+	got := client.Article.GetX(ctx, entity.ID)
+	if got.Status != article.StatusSCHEDULED {
+		t.Fatalf("stored status = %q, want %q", got.Status, article.StatusSCHEDULED)
+	}
+	if got.ScheduledAt == nil || !got.ScheduledAt.Equal(scheduledAt) {
+		t.Fatalf("stored scheduled_at = %v, want %v", got.ScheduledAt, scheduledAt)
+	}
+}
+
+func TestPublishScheduledArticleRejectsFutureSchedule(t *testing.T) {
+	client := openArticleInvariantTestClient(t, "article_scheduled_publish_future_guard")
+	ctx := context.Background()
+
+	entity := client.Article.Create().
+		SetTitle("Future article").
+		SetStatus(article.StatusSCHEDULED).
+		SetScheduledAt(time.Now().Add(time.Hour)).
+		SaveX(ctx)
+	repo := NewArticleRepo(client, "sqlite3")
+
+	err := repo.PublishScheduledArticle(ctx, entity.ID)
+	if !errors.Is(err, constant.ErrConflict) {
+		t.Fatalf("PublishScheduledArticle() error = %v, want ErrConflict", err)
+	}
+	got := client.Article.GetX(ctx, entity.ID)
+	if got.Status != article.StatusSCHEDULED {
+		t.Fatalf("stored status = %q, want %q", got.Status, article.StatusSCHEDULED)
+	}
+}

--- a/internal/infra/persistence/ent/article_repo.go
+++ b/internal/infra/persistence/ent/article_repo.go
@@ -25,6 +25,17 @@ type articleRepo struct {
 	dbType string
 }
 
+func articleStatusRequiresTitle(status string) bool {
+	return status == string(article.StatusPUBLISHED) || status == string(article.StatusSCHEDULED)
+}
+
+func mapArticlePersistenceError(err error) error {
+	if ent.IsConstraintError(err) {
+		return fmt.Errorf("%w: 文章数据约束冲突", constant.ErrConflict)
+	}
+	return err
+}
+
 // NewArticleRepo 是 articleRepo 的构造函数。
 func NewArticleRepo(db *ent.Client, dbType string) repository.ArticleRepository {
 	return &articleRepo{db: db, dbType: dbType}
@@ -550,6 +561,13 @@ func (r *articleRepo) IncrementViewCount(ctx context.Context, publicID string) e
 
 // Create 创建新文章
 func (r *articleRepo) Create(ctx context.Context, params *model.CreateArticleParams) (*model.Article, error) {
+	if articleStatusRequiresTitle(params.Status) && strings.TrimSpace(params.Title) == "" {
+		return nil, fmt.Errorf("%w: 公开或定时文章必须填写标题", constant.ErrConflict)
+	}
+	if (params.CreateIdempotencyKey == "") != (params.CreateRequestDigest == "") {
+		return nil, fmt.Errorf("%w: 创建幂等键与请求摘要必须同时提供", constant.ErrBadRequest)
+	}
+
 	topImgURL := params.TopImgURL
 	if topImgURL == "" {
 		topImgURL = params.CoverURL
@@ -585,6 +603,12 @@ func (r *articleRepo) Create(ctx context.Context, params *model.CreateArticlePar
 		SetCopyrightAuthorHref(params.CopyrightAuthorHref).
 		SetCopyrightURL(params.CopyrightURL).
 		SetKeywords(params.Keywords)
+
+	if params.CreateIdempotencyKey != "" {
+		creator.
+			SetCreateIdempotencyKey(params.CreateIdempotencyKey).
+			SetCreateRequestDigest(params.CreateRequestDigest)
+	}
 
 	if params.Abbrlink != "" {
 		creator.SetAbbrlink(params.Abbrlink)
@@ -640,11 +664,45 @@ func (r *articleRepo) Create(ctx context.Context, params *model.CreateArticlePar
 	newEntity, err := creator.Save(ctx)
 	if err != nil {
 		log.Printf("[Repository.Create] 保存失败: %v", err)
-		return nil, err
+		return nil, mapArticlePersistenceError(err)
 	}
 
 	publicID, _ := idgen.GeneratePublicID(newEntity.ID, idgen.EntityTypeArticle)
 	return r.GetByID(ctx, publicID)
+}
+
+// FindByCreateIdempotencyKey 根据内部幂等键查找已创建文章及其请求摘要。
+func (r *articleRepo) FindByCreateIdempotencyKey(ctx context.Context, key string) (*model.Article, string, error) {
+	if key == "" {
+		return nil, "", nil
+	}
+
+	entity, err := r.db.Article.Query().
+		Where(
+			article.CreateIdempotencyKeyEQ(key),
+		).
+		WithPostTags().
+		WithPostCategories().
+		Only(ctx)
+	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, "", nil
+		}
+		return nil, "", fmt.Errorf("查询文章创建幂等键失败: %w", err)
+	}
+	if entity.DeletedAt != nil {
+		return nil, "", fmt.Errorf("%w: 幂等创建结果已删除", constant.ErrConflict)
+	}
+
+	digest := ""
+	if entity.CreateRequestDigest != nil {
+		digest = *entity.CreateRequestDigest
+	}
+	articleModel, err := r.toModel(entity)
+	if err != nil {
+		return nil, "", err
+	}
+	return articleModel, digest, nil
 }
 
 // Update 更新文章
@@ -653,7 +711,47 @@ func (r *articleRepo) Update(ctx context.Context, publicID string, req *model.Up
 	if err != nil {
 		return nil, err
 	}
-	updater := r.db.Article.UpdateOneID(dbID)
+	updater := r.db.Article.UpdateOneID(dbID).
+		Where(article.DeletedAtIsNil())
+	invariantGuarded := false
+	if req.Title != nil && req.Status != nil &&
+		articleStatusRequiresTitle(*req.Status) && strings.TrimSpace(*req.Title) == "" {
+		return nil, fmt.Errorf("%w: 公开或定时文章必须填写标题", constant.ErrConflict)
+	}
+	if req.Status != nil && articleStatusRequiresTitle(*req.Status) && req.Title == nil {
+		current, currentErr := r.db.Article.Query().
+			Where(article.ID(dbID), article.DeletedAtIsNil()).
+			Select(article.FieldTitle).
+			Only(ctx)
+		if currentErr != nil {
+			if ent.IsNotFound(currentErr) {
+				return nil, fmt.Errorf("%w: 文章不存在", constant.ErrNotFound)
+			}
+			return nil, fmt.Errorf("读取文章标题失败: %w", currentErr)
+		}
+		if strings.TrimSpace(current.Title) == "" {
+			return nil, fmt.Errorf("%w: 公开或定时文章必须填写标题", constant.ErrConflict)
+		}
+		updater.Where(article.TitleEQ(current.Title))
+		invariantGuarded = true
+	}
+	if req.Title != nil && strings.TrimSpace(*req.Title) == "" && req.Status == nil {
+		current, currentErr := r.db.Article.Query().
+			Where(article.ID(dbID), article.DeletedAtIsNil()).
+			Select(article.FieldStatus).
+			Only(ctx)
+		if currentErr != nil {
+			if ent.IsNotFound(currentErr) {
+				return nil, fmt.Errorf("%w: 文章不存在", constant.ErrNotFound)
+			}
+			return nil, fmt.Errorf("读取文章状态失败: %w", currentErr)
+		}
+		if articleStatusRequiresTitle(string(current.Status)) {
+			return nil, fmt.Errorf("%w: 公开或定时文章不能清空标题", constant.ErrConflict)
+		}
+		updater.Where(article.StatusEQ(current.Status))
+		invariantGuarded = true
+	}
 	if req.Title != nil {
 		updater.SetTitle(*req.Title)
 	}
@@ -819,7 +917,22 @@ func (r *articleRepo) Update(ctx context.Context, publicID string, req *model.Up
 	_, err = updater.Save(ctx)
 	if err != nil {
 		log.Printf("[Repository.Update] 保存失败: %v", err)
-		return nil, err
+		if invariantGuarded && ent.IsNotFound(err) {
+			exists, existsErr := r.db.Article.Query().
+				Where(article.ID(dbID), article.DeletedAtIsNil()).
+				Exist(ctx)
+			if existsErr != nil {
+				return nil, fmt.Errorf("确认文章状态失败: %w", existsErr)
+			}
+			if exists {
+				return nil, fmt.Errorf("%w: 标题与状态更新发生冲突", constant.ErrConflict)
+			}
+			return nil, fmt.Errorf("%w: 文章不存在", constant.ErrNotFound)
+		}
+		if ent.IsNotFound(err) {
+			return nil, fmt.Errorf("%w: 文章不存在", constant.ErrNotFound)
+		}
+		return nil, mapArticlePersistenceError(err)
 	}
 
 	return r.GetByID(ctx, publicID)
@@ -1027,6 +1140,9 @@ func (r *articleRepo) GetByID(ctx context.Context, publicID string) (*model.Arti
 		WithPostCategories().
 		Only(ctx)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			return nil, fmt.Errorf("%w: 文章不存在", constant.ErrNotFound)
+		}
 		return nil, err
 	}
 	return r.toModel(entity)
@@ -1096,11 +1212,35 @@ func (r *articleRepo) PublishScheduledArticle(ctx context.Context, articleID uin
 	// 先获取文章的 scheduled_at 时间
 	articleEntity, err := r.db.Article.Get(ctx, articleID)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			return fmt.Errorf("%w: 文章不存在", constant.ErrNotFound)
+		}
 		return fmt.Errorf("获取文章 %d 失败: %w", articleID, err)
+	}
+	if strings.TrimSpace(articleEntity.Title) == "" {
+		return fmt.Errorf("%w: 无标题文章不能定时发布", constant.ErrConflict)
+	}
+	if articleEntity.DeletedAt != nil {
+		return fmt.Errorf("%w: 文章不存在", constant.ErrNotFound)
+	}
+	if articleEntity.Status != article.StatusSCHEDULED {
+		return fmt.Errorf("%w: 文章不再是定时发布状态", constant.ErrConflict)
+	}
+	if articleEntity.ScheduledAt == nil {
+		return fmt.Errorf("%w: 定时文章缺少发布时间", constant.ErrConflict)
+	}
+	if articleEntity.ScheduledAt.After(time.Now()) {
+		return fmt.Errorf("%w: 定时发布时间尚未到达", constant.ErrConflict)
 	}
 
 	// 更新文章状态为已发布
 	updater := r.db.Article.UpdateOneID(articleID).
+		Where(
+			article.StatusEQ(article.StatusSCHEDULED),
+			article.DeletedAtIsNil(),
+			article.TitleEQ(articleEntity.Title),
+			article.ScheduledAtEQ(*articleEntity.ScheduledAt),
+		).
 		SetStatus(article.StatusPUBLISHED).
 		ClearScheduledAt() // 清除定时发布时间
 
@@ -1112,6 +1252,21 @@ func (r *articleRepo) PublishScheduledArticle(ctx context.Context, articleID uin
 
 	_, err = updater.Save(ctx)
 	if err != nil {
+		if ent.IsNotFound(err) {
+			exists, existsErr := r.db.Article.Query().
+				Where(article.ID(articleID), article.DeletedAtIsNil()).
+				Exist(ctx)
+			if existsErr != nil {
+				return fmt.Errorf("确认定时文章状态失败: %w", existsErr)
+			}
+			if exists {
+				return fmt.Errorf("%w: 定时文章状态或标题已变化", constant.ErrConflict)
+			}
+			return fmt.Errorf("%w: 文章不存在", constant.ErrNotFound)
+		}
+		if ent.IsConstraintError(err) {
+			return fmt.Errorf("%w: 定时文章数据约束冲突", constant.ErrConflict)
+		}
 		return fmt.Errorf("发布定时文章 %d 失败: %w", articleID, err)
 	}
 

--- a/pkg/domain/model/article.go
+++ b/pkg/domain/model/article.go
@@ -82,7 +82,7 @@ type Article struct {
 
 // CreateArticleRequest 定义了创建文章的请求体
 type CreateArticleRequest struct {
-	Title                string              `json:"title" binding:"required"`
+	Title                string              `json:"title"` // 草稿允许暂时先不设置标题
 	ContentMd            string              `json:"content_md"`
 	CoverURL             string              `json:"cover_url"`
 	Status               string              `json:"status" binding:"omitempty,oneof=DRAFT PUBLISHED ARCHIVED SCHEDULED"`

--- a/pkg/domain/model/article.go
+++ b/pkg/domain/model/article.go
@@ -314,7 +314,9 @@ type UpdateArticleComputedParams struct {
 // CreateArticleParams 封装了创建文章时需要持久化的所有数据。
 type CreateArticleParams struct {
 	Title                string
-	OwnerID              uint // 文章作者ID（多人共创功能）
+	CreateIdempotencyKey string // 内部字段：按认证用户隔离后的创建幂等键摘要
+	CreateRequestDigest  string // 内部字段：规范化创建请求摘要
+	OwnerID              uint   // 文章作者ID（多人共创功能）
 	ContentMd            string
 	ContentHTML          string
 	CoverURL             string

--- a/pkg/domain/repository/article_repo.go
+++ b/pkg/domain/repository/article_repo.go
@@ -23,6 +23,10 @@ type ArticleRepository interface {
 	// Create 方法接收一个包含所有必需数据的参数对象，返回创建后的文章领域模型。
 	Create(ctx context.Context, params *model.CreateArticleParams) (*model.Article, error)
 
+	// FindByCreateIdempotencyKey 根据内部创建幂等键查找文章及其请求摘要。
+	// 未找到时返回 (nil, "", nil)。
+	FindByCreateIdempotencyKey(ctx context.Context, key string) (*model.Article, string, error)
+
 	// GetByID 根据公共ID获取单个文章的完整信息（包括关联数据）。
 	GetByID(ctx context.Context, publicID string) (*model.Article, error)
 

--- a/pkg/handler/article/handler.go
+++ b/pkg/handler/article/handler.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/anzhiyu-c/anheyu-app/ent"
 	"github.com/anzhiyu-c/anheyu-app/internal/pkg/auth"
+	"github.com/anzhiyu-c/anheyu-app/pkg/constant"
 	"github.com/anzhiyu-c/anheyu-app/pkg/domain/model"
 	"github.com/anzhiyu-c/anheyu-app/pkg/idgen"
 	"github.com/anzhiyu-c/anheyu-app/pkg/response"
@@ -31,6 +32,19 @@ type Handler struct {
 
 type uploadArticleImageWithOptions interface {
 	UploadArticleImageWithGroupOptions(ctx context.Context, ownerID, userGroupID uint, fileReader io.Reader, originalFilename string, options articleSvc.UploadArticleImageOptions) (fileURL string, publicFileID string, err error)
+}
+
+func mutationErrorStatus(err error) int {
+	switch {
+	case errors.Is(err, constant.ErrBadRequest):
+		return http.StatusBadRequest
+	case errors.Is(err, constant.ErrNotFound):
+		return http.StatusNotFound
+	case errors.Is(err, constant.ErrConflict):
+		return http.StatusConflict
+	default:
+		return http.StatusInternalServerError
+	}
 }
 
 // NewHandler 是 Handler 的构造函数。
@@ -240,9 +254,11 @@ func (h *Handler) GetRandom(c *gin.Context) {
 // @Tags         文章管理
 // @Accept       json
 // @Produce      json
+// @Param        Idempotency-Key header string false "可选的创建幂等键，最长 200 字节" maxlength(200)
 // @Param        article body model.CreateArticleRequest true "创建文章的请求体"
 // @Success      200 {object} response.Response{data=model.ArticleResponse} "成功响应"
 // @Failure      400 {object} response.Response "请求参数错误"
+// @Failure      409 {object} response.Response "幂等键或文章数据冲突"
 // @Failure      500 {object} response.Response "服务器内部错误"
 // @Router       /articles [post]
 func (h *Handler) Create(c *gin.Context) {
@@ -279,13 +295,32 @@ func (h *Handler) Create(c *gin.Context) {
 	clientIP := util.GetRealClientIP(c)
 	// 获取客户端 Referer，用于 NSUUU API 白名单验证
 	referer := c.GetHeader("Referer")
+	idempotencyValues, idempotencyKeyPresent := c.Request.Header[http.CanonicalHeaderKey("Idempotency-Key")]
+	if len(idempotencyValues) > 1 {
+		response.Fail(c, http.StatusBadRequest, "Idempotency-Key 只能提供一次")
+		return
+	}
+	idempotencyKey := ""
+	if len(idempotencyValues) == 1 {
+		idempotencyKey = idempotencyValues[0]
+	}
 
 	// 调用 Service 时传递 IP 地址和 Referer
 	log.Printf("[Handler.Create] 调用 Service.Create...")
-	article, err := h.svc.Create(c.Request.Context(), &req, clientIP, referer)
+	article, err := h.svc.CreateWithOptions(
+		c.Request.Context(),
+		&req,
+		clientIP,
+		referer,
+		articleSvc.CreateOptions{
+			ActorUserID:           claims.UserID,
+			IdempotencyKey:        idempotencyKey,
+			IdempotencyKeyPresent: idempotencyKeyPresent,
+		},
+	)
 	if err != nil {
 		log.Printf("[Handler.Create] ❌ Service.Create 失败: %v", err)
-		response.Fail(c, http.StatusInternalServerError, "创建文章失败: "+err.Error())
+		response.Fail(c, mutationErrorStatus(err), "创建文章失败: "+err.Error())
 		return
 	}
 
@@ -442,6 +477,8 @@ func (h *Handler) Get(c *gin.Context) {
 // @Param        article body model.UpdateArticleRequest true "更新文章的请求体"
 // @Success      200 {object} response.Response{data=model.ArticleResponse} "成功响应"
 // @Failure      400 {object} response.Response "请求参数错误"
+// @Failure      404 {object} response.Response "文章不存在"
+// @Failure      409 {object} response.Response "文章状态或数据冲突"
 // @Failure      500 {object} response.Response "服务器内部错误"
 // @Router       /articles/{id} [put]
 func (h *Handler) Update(c *gin.Context) {
@@ -487,7 +524,7 @@ func (h *Handler) Update(c *gin.Context) {
 	article, err := h.svc.Update(c.Request.Context(), id, &req, clientIP, referer)
 	if err != nil {
 		log.Printf("[Handler.Update] ❌ Service.Update 失败: %v", err)
-		response.Fail(c, http.StatusInternalServerError, "更新文章失败: "+err.Error())
+		response.Fail(c, mutationErrorStatus(err), "更新文章失败: "+err.Error())
 		return
 	}
 

--- a/pkg/handler/article/handler_autosave_test.go
+++ b/pkg/handler/article/handler_autosave_test.go
@@ -1,0 +1,168 @@
+package article
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/anzhiyu-c/anheyu-app/internal/pkg/auth"
+	"github.com/anzhiyu-c/anheyu-app/pkg/constant"
+	"github.com/anzhiyu-c/anheyu-app/pkg/domain/model"
+	articleSvc "github.com/anzhiyu-c/anheyu-app/pkg/service/article"
+	"github.com/gin-gonic/gin"
+)
+
+type failingArticleService struct {
+	articleSvc.Service
+	err error
+}
+
+func (s failingArticleService) Create(
+	context.Context,
+	*model.CreateArticleRequest,
+	string,
+	string,
+) (*model.ArticleResponse, error) {
+	return nil, s.err
+}
+
+func (s failingArticleService) CreateWithOptions(
+	context.Context,
+	*model.CreateArticleRequest,
+	string,
+	string,
+	articleSvc.CreateOptions,
+) (*model.ArticleResponse, error) {
+	return nil, s.err
+}
+
+func (s failingArticleService) Update(
+	context.Context,
+	string,
+	*model.UpdateArticleRequest,
+	string,
+	string,
+) (*model.ArticleResponse, error) {
+	return nil, s.err
+}
+
+func newArticleHandlerTestContext(t *testing.T, method, target, body string) (*gin.Context, *httptest.ResponseRecorder) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(method, target, bytes.NewBufferString(body))
+	ctx.Request.Header.Set("Content-Type", "application/json")
+	ctx.Set(auth.ClaimsKey, &auth.CustomClaims{UserID: "test-user"})
+	return ctx, recorder
+}
+
+func TestCreateMapsArticleBusinessErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		serviceErr error
+		wantStatus int
+	}{
+		{name: "bad request", serviceErr: fmtWrap(constant.ErrBadRequest, "发布文章必须填写标题"), wantStatus: http.StatusBadRequest},
+		{name: "not found", serviceErr: fmtWrap(constant.ErrNotFound, "文章不存在"), wantStatus: http.StatusNotFound},
+		{name: "conflict", serviceErr: fmtWrap(constant.ErrConflict, "幂等键冲突"), wantStatus: http.StatusConflict},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, recorder := newArticleHandlerTestContext(t, http.MethodPost, "/api/articles", `{"status":"PUBLISHED"}`)
+			NewHandler(failingArticleService{err: tt.serviceErr}).Create(ctx)
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", recorder.Code, tt.wantStatus, recorder.Body.String())
+			}
+		})
+	}
+}
+
+func TestUpdateMapsArticleBusinessErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		serviceErr error
+		wantStatus int
+	}{
+		{name: "bad request", serviceErr: fmtWrap(constant.ErrBadRequest, "发布文章必须填写标题"), wantStatus: http.StatusBadRequest},
+		{name: "not found", serviceErr: fmtWrap(constant.ErrNotFound, "文章不存在"), wantStatus: http.StatusNotFound},
+		{name: "conflict", serviceErr: fmtWrap(constant.ErrConflict, "文章状态冲突"), wantStatus: http.StatusConflict},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, recorder := newArticleHandlerTestContext(t, http.MethodPut, "/api/articles/article-id", `{"status":"PUBLISHED"}`)
+			ctx.Params = gin.Params{{Key: "id", Value: "article-id"}}
+			NewHandler(failingArticleService{err: tt.serviceErr}).Update(ctx)
+
+			if recorder.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", recorder.Code, tt.wantStatus, recorder.Body.String())
+			}
+		})
+	}
+}
+
+type capturingArticleService struct {
+	articleSvc.Service
+	options *articleSvc.CreateOptions
+}
+
+func (s *capturingArticleService) CreateWithOptions(
+	_ context.Context,
+	_ *model.CreateArticleRequest,
+	_, _ string,
+	options articleSvc.CreateOptions,
+) (*model.ArticleResponse, error) {
+	s.options = &options
+	if strings.TrimSpace(options.IdempotencyKey) == "" && options.IdempotencyKeyPresent {
+		return nil, fmtWrap(constant.ErrBadRequest, "Idempotency-Key 不能为空")
+	}
+	return &model.ArticleResponse{ID: "article-id", Status: "DRAFT"}, nil
+}
+
+func TestCreatePassesIdempotencyHeaderWithAuthenticatedUserScope(t *testing.T) {
+	ctx, recorder := newArticleHandlerTestContext(t, http.MethodPost, "/api/articles", `{"status":"DRAFT"}`)
+	ctx.Request.Header.Set("Idempotency-Key", "autosave-key")
+	svc := &capturingArticleService{}
+
+	NewHandler(svc).Create(ctx)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if svc.options == nil {
+		t.Fatal("CreateWithOptions() was not called")
+	}
+	if svc.options.ActorUserID != "test-user" {
+		t.Fatalf("ActorUserID = %q, want %q", svc.options.ActorUserID, "test-user")
+	}
+	if svc.options.IdempotencyKey != "autosave-key" || !svc.options.IdempotencyKeyPresent {
+		t.Fatalf("idempotency options = %+v, want the supplied header", *svc.options)
+	}
+}
+
+func TestCreateRejectsRepeatedIdempotencyHeader(t *testing.T) {
+	ctx, recorder := newArticleHandlerTestContext(t, http.MethodPost, "/api/articles", `{"status":"DRAFT"}`)
+	ctx.Request.Header.Add("Idempotency-Key", "first")
+	ctx.Request.Header.Add("Idempotency-Key", "second")
+	svc := &capturingArticleService{}
+
+	NewHandler(svc).Create(ctx)
+
+	if recorder.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", recorder.Code, http.StatusBadRequest, recorder.Body.String())
+	}
+	if svc.options != nil {
+		t.Fatal("CreateWithOptions() was called for repeated Idempotency-Key headers")
+	}
+}
+
+func fmtWrap(base error, message string) error {
+	return errors.Join(base, errors.New(message))
+}

--- a/pkg/service/article/autosave_validation_test.go
+++ b/pkg/service/article/autosave_validation_test.go
@@ -1,0 +1,177 @@
+package article
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/anzhiyu-c/anheyu-app/ent/enttest"
+	persistenceEnt "github.com/anzhiyu-c/anheyu-app/internal/infra/persistence/ent"
+	"github.com/anzhiyu-c/anheyu-app/internal/pkg/event"
+	"github.com/anzhiyu-c/anheyu-app/pkg/constant"
+	"github.com/anzhiyu-c/anheyu-app/pkg/domain/model"
+	"github.com/anzhiyu-c/anheyu-app/pkg/domain/repository"
+	"github.com/anzhiyu-c/anheyu-app/pkg/idgen"
+	appParser "github.com/anzhiyu-c/anheyu-app/pkg/service/parser"
+	"github.com/anzhiyu-c/anheyu-app/pkg/service/setting"
+	_ "github.com/ncruces/go-sqlite3/driver"
+	_ "github.com/ncruces/go-sqlite3/embed"
+)
+
+var errUnexpectedArticleWrite = errors.New("unexpected article write")
+
+type articleValidationSettingService struct {
+	setting.SettingService
+}
+
+func (articleValidationSettingService) Get(string) string {
+	return ""
+}
+
+type rejectingArticleTransactionManager struct {
+	called bool
+}
+
+func (m *rejectingArticleTransactionManager) Do(context.Context, func(repository.Repositories) error) error {
+	m.called = true
+	return errUnexpectedArticleWrite
+}
+
+type articleValidationRepo struct {
+	repository.ArticleRepository
+	oldArticle *model.Article
+	updateReq  *model.UpdateArticleRequest
+}
+
+func (r *articleValidationRepo) GetByID(context.Context, string) (*model.Article, error) {
+	return r.oldArticle, nil
+}
+
+func (r *articleValidationRepo) Update(
+	_ context.Context,
+	_ string,
+	req *model.UpdateArticleRequest,
+	_ *model.UpdateArticleComputedParams,
+) (*model.Article, error) {
+	r.updateReq = req
+	return nil, errUnexpectedArticleWrite
+}
+
+type articleValidationTransactionManager struct {
+	repo repository.ArticleRepository
+}
+
+func (m articleValidationTransactionManager) Do(ctx context.Context, fn func(repository.Repositories) error) error {
+	return fn(repository.Repositories{Article: m.repo})
+}
+
+func newArticleValidationParser(t *testing.T) *appParser.Service {
+	t.Helper()
+	bus := event.NewEventBus()
+	t.Cleanup(bus.Shutdown)
+	return appParser.NewService(articleValidationSettingService{}, bus)
+}
+
+func TestCreateRejectsBlankTitleAfterScheduledStatusNormalization(t *testing.T) {
+	txManager := &rejectingArticleTransactionManager{}
+	svc := &serviceImpl{
+		txManager: txManager,
+		parserSvc: newArticleValidationParser(t),
+	}
+	future := time.Now().Add(time.Hour).Format(time.RFC3339)
+
+	_, err := svc.Create(context.Background(), &model.CreateArticleRequest{
+		Title:       " \t ",
+		Status:      "DRAFT",
+		ScheduledAt: &future,
+	}, "", "")
+
+	if !errors.Is(err, constant.ErrBadRequest) {
+		t.Fatalf("Create() error = %v, want ErrBadRequest", err)
+	}
+	if txManager.called {
+		t.Fatal("Create() started a transaction for an invalid final title/status pair")
+	}
+}
+
+func TestUpdateRejectsBlankTitleAfterScheduledStatusNormalization(t *testing.T) {
+	repo := &articleValidationRepo{
+		oldArticle: &model.Article{
+			ID:     "article-id",
+			Title:  "",
+			Status: "DRAFT",
+		},
+	}
+	svc := &serviceImpl{
+		txManager: articleValidationTransactionManager{repo: repo},
+	}
+	future := time.Now().Add(time.Hour).Format(time.RFC3339)
+
+	_, err := svc.Update(context.Background(), "article-id", &model.UpdateArticleRequest{
+		ScheduledAt: &future,
+	}, "", "")
+
+	if !errors.Is(err, constant.ErrBadRequest) {
+		t.Fatalf("Update() error = %v, want ErrBadRequest", err)
+	}
+	if repo.updateReq != nil {
+		t.Fatal("Update() called the repository for an invalid final title/status pair")
+	}
+}
+
+func TestUpdateDoesNotWriteTitleWhenOnlyStatusWasRequested(t *testing.T) {
+	repo := &articleValidationRepo{
+		oldArticle: &model.Article{
+			ID:     "article-id",
+			Title:  "Original title",
+			Status: "DRAFT",
+		},
+	}
+	svc := &serviceImpl{
+		txManager: articleValidationTransactionManager{repo: repo},
+	}
+	published := "PUBLISHED"
+
+	_, err := svc.Update(context.Background(), "article-id", &model.UpdateArticleRequest{
+		Status: &published,
+	}, "", "")
+
+	if !errors.Is(err, errUnexpectedArticleWrite) {
+		t.Fatalf("Update() error = %v, want errUnexpectedArticleWrite", err)
+	}
+	if repo.updateReq == nil {
+		t.Fatal("Update() did not call the repository")
+	}
+	if repo.updateReq.Title != nil {
+		t.Fatalf("repository title = %q, want unspecified", *repo.updateReq.Title)
+	}
+	if repo.updateReq.Status == nil || *repo.updateReq.Status != published {
+		t.Fatalf("repository status = %v, want %q", repo.updateReq.Status, published)
+	}
+}
+
+func TestUpdateMapsMissingArticleFromRealRepositoryToErrNotFound(t *testing.T) {
+	if err := idgen.InitSqidsEncoderWithSeed("service_update_missing_article"); err != nil {
+		t.Fatalf("InitSqidsEncoderWithSeed() error = %v", err)
+	}
+	client := enttest.Open(t, "sqlite3", "file:service_update_missing_article?mode=memory&cache=shared&_fk=1")
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("client.Close() error = %v", err)
+		}
+	})
+	repo := persistenceEnt.NewArticleRepo(client, "sqlite3")
+	publicID, err := idgen.GeneratePublicID(999, idgen.EntityTypeArticle)
+	if err != nil {
+		t.Fatalf("GeneratePublicID() error = %v", err)
+	}
+	svc := &serviceImpl{
+		txManager: articleValidationTransactionManager{repo: repo},
+	}
+
+	_, err = svc.Update(context.Background(), publicID, &model.UpdateArticleRequest{}, "", "")
+	if !errors.Is(err, constant.ErrNotFound) {
+		t.Fatalf("Update() error = %v, want ErrNotFound", err)
+	}
+}

--- a/pkg/service/article/idempotency_test.go
+++ b/pkg/service/article/idempotency_test.go
@@ -1,0 +1,371 @@
+package article
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/anzhiyu-c/anheyu-app/internal/pkg/event"
+	"github.com/anzhiyu-c/anheyu-app/pkg/constant"
+	"github.com/anzhiyu-c/anheyu-app/pkg/domain/model"
+	"github.com/anzhiyu-c/anheyu-app/pkg/domain/repository"
+	appParser "github.com/anzhiyu-c/anheyu-app/pkg/service/parser"
+	"github.com/anzhiyu-c/anheyu-app/pkg/service/setting"
+	"github.com/anzhiyu-c/anheyu-app/pkg/service/utility"
+)
+
+type idempotencyArticleRecord struct {
+	article *model.Article
+	digest  string
+}
+
+type idempotencyArticleRepo struct {
+	repository.ArticleRepository
+	mu          sync.Mutex
+	byKey       map[string]idempotencyArticleRecord
+	createCalls int
+
+	forceConcurrentPreflight bool
+	preflightCount           int
+	preflightBarrier         chan struct{}
+}
+
+func newIdempotencyArticleRepo() *idempotencyArticleRepo {
+	return &idempotencyArticleRepo{byKey: make(map[string]idempotencyArticleRecord)}
+}
+
+func (r *idempotencyArticleRepo) FindByCreateIdempotencyKey(
+	_ context.Context,
+	key string,
+) (*model.Article, string, error) {
+	r.mu.Lock()
+	record, ok := r.byKey[key]
+	if ok {
+		articleCopy := *record.article
+		r.mu.Unlock()
+		return &articleCopy, record.digest, nil
+	}
+	if r.forceConcurrentPreflight && r.preflightCount < 2 {
+		r.preflightCount++
+		if r.preflightCount == 2 {
+			close(r.preflightBarrier)
+		}
+		barrier := r.preflightBarrier
+		r.mu.Unlock()
+		<-barrier
+		return nil, "", nil
+	}
+	r.mu.Unlock()
+	return nil, "", nil
+}
+
+func (r *idempotencyArticleRepo) Create(
+	_ context.Context,
+	params *model.CreateArticleParams,
+) (*model.Article, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.createCalls++
+	if params.CreateIdempotencyKey != "" {
+		if _, exists := r.byKey[params.CreateIdempotencyKey]; exists {
+			return nil, fmt.Errorf("%w: duplicate create idempotency key", constant.ErrConflict)
+		}
+	}
+	created := &model.Article{
+		ID:      fmt.Sprintf("article-%d", r.createCalls),
+		OwnerID: params.OwnerID,
+		Title:   params.Title,
+		Status:  params.Status,
+	}
+	if params.CreateIdempotencyKey != "" {
+		r.byKey[params.CreateIdempotencyKey] = idempotencyArticleRecord{
+			article: created,
+			digest:  params.CreateRequestDigest,
+		}
+	}
+	return created, nil
+}
+
+func (r *idempotencyArticleRepo) GetSiteStats(context.Context) (*model.SiteStats, error) {
+	return &model.SiteStats{}, nil
+}
+
+type idempotencyPostTagRepo struct {
+	repository.PostTagRepository
+}
+
+func (idempotencyPostTagRepo) UpdateCount(context.Context, []uint, []uint) error {
+	return nil
+}
+
+type idempotencyPostCategoryRepo struct {
+	repository.PostCategoryRepository
+}
+
+func (idempotencyPostCategoryRepo) UpdateCount(context.Context, []uint, []uint) error {
+	return nil
+}
+
+type idempotencyTransactionManager struct {
+	mu       sync.Mutex
+	calls    int
+	articles repository.ArticleRepository
+}
+
+func (m *idempotencyTransactionManager) Do(ctx context.Context, fn func(repository.Repositories) error) error {
+	m.mu.Lock()
+	m.calls++
+	m.mu.Unlock()
+	return fn(repository.Repositories{
+		Article:      m.articles,
+		PostTag:      idempotencyPostTagRepo{},
+		PostCategory: idempotencyPostCategoryRepo{},
+	})
+}
+
+func (m *idempotencyTransactionManager) callCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
+type idempotencyCacheService struct {
+	utility.CacheService
+}
+
+func (idempotencyCacheService) Delete(context.Context, ...string) error {
+	return nil
+}
+
+type idempotencySettingService struct {
+	setting.SettingService
+}
+
+func (idempotencySettingService) Get(string) string {
+	return ""
+}
+
+func (idempotencySettingService) UpdateSettings(context.Context, map[string]string) error {
+	return nil
+}
+
+func newIdempotencyArticleService(t *testing.T) (*serviceImpl, *idempotencyArticleRepo, *idempotencyTransactionManager) {
+	t.Helper()
+	repo := newIdempotencyArticleRepo()
+	txManager := &idempotencyTransactionManager{articles: repo}
+	settingSvc := idempotencySettingService{}
+	bus := event.NewEventBus()
+	t.Cleanup(bus.Shutdown)
+	return &serviceImpl{
+		repo:       repo,
+		txManager:  txManager,
+		cacheSvc:   idempotencyCacheService{},
+		settingSvc: settingSvc,
+		parserSvc:  appParser.NewService(settingSvc, bus),
+	}, repo, txManager
+}
+
+func TestCreateWithOptionsReplaysSameIdempotencyRequestWithoutSecondTransaction(t *testing.T) {
+	svc, repo, txManager := newIdempotencyArticleService(t)
+	options := CreateOptions{ActorUserID: "user-1", IdempotencyKey: "autosave-key"}
+
+	first, err := svc.CreateWithOptions(context.Background(), &model.CreateArticleRequest{
+		ContentMd: "first body",
+		Title:     "  ",
+		Summaries: []string{"", "summary"},
+	}, "", "", options)
+	if err != nil {
+		t.Fatalf("first CreateWithOptions() error = %v", err)
+	}
+	second, err := svc.CreateWithOptions(context.Background(), &model.CreateArticleRequest{
+		ContentMd: "first body",
+		Status:    "DRAFT",
+		Summaries: []string{"summary"},
+	}, "", "", options)
+	if err != nil {
+		t.Fatalf("second CreateWithOptions() error = %v", err)
+	}
+
+	if first.ID != second.ID {
+		t.Fatalf("IDs = (%q, %q), want identical IDs", first.ID, second.ID)
+	}
+	if txManager.callCount() != 1 {
+		t.Fatalf("transaction calls = %d, want 1", txManager.callCount())
+	}
+	if repo.createCalls != 1 {
+		t.Fatalf("repository create calls = %d, want 1", repo.createCalls)
+	}
+}
+
+func TestCreateWithOptionsRejectsIdempotencyKeyReuseWithDifferentRequest(t *testing.T) {
+	svc, _, txManager := newIdempotencyArticleService(t)
+	options := CreateOptions{ActorUserID: "user-1", IdempotencyKey: "autosave-key"}
+
+	if _, err := svc.CreateWithOptions(context.Background(), &model.CreateArticleRequest{
+		ContentMd: "first body",
+		Status:    "DRAFT",
+	}, "", "", options); err != nil {
+		t.Fatalf("first CreateWithOptions() error = %v", err)
+	}
+	_, err := svc.CreateWithOptions(context.Background(), &model.CreateArticleRequest{
+		ContentMd: "different body",
+		Status:    "DRAFT",
+	}, "", "", options)
+
+	if !errors.Is(err, constant.ErrConflict) {
+		t.Fatalf("second CreateWithOptions() error = %v, want ErrConflict", err)
+	}
+	if txManager.callCount() != 1 {
+		t.Fatalf("transaction calls = %d, want 1", txManager.callCount())
+	}
+}
+
+func TestCreateWithOptionsScopesIdempotencyKeyByAuthenticatedUser(t *testing.T) {
+	svc, repo, _ := newIdempotencyArticleService(t)
+	request := func() *model.CreateArticleRequest {
+		return &model.CreateArticleRequest{ContentMd: "body", Status: "DRAFT"}
+	}
+
+	first, err := svc.CreateWithOptions(context.Background(), request(), "", "", CreateOptions{
+		ActorUserID:    "user-1",
+		IdempotencyKey: "shared-key",
+	})
+	if err != nil {
+		t.Fatalf("first CreateWithOptions() error = %v", err)
+	}
+	second, err := svc.CreateWithOptions(context.Background(), request(), "", "", CreateOptions{
+		ActorUserID:    "user-2",
+		IdempotencyKey: "shared-key",
+	})
+	if err != nil {
+		t.Fatalf("second CreateWithOptions() error = %v", err)
+	}
+
+	if first.ID == second.ID {
+		t.Fatalf("IDs = (%q, %q), want separate articles for separate authenticated users", first.ID, second.ID)
+	}
+	if repo.createCalls != 2 {
+		t.Fatalf("repository create calls = %d, want 2", repo.createCalls)
+	}
+}
+
+func TestCreateWithOptionsRejectsOversizedIdempotencyKey(t *testing.T) {
+	svc, _, txManager := newIdempotencyArticleService(t)
+	_, err := svc.CreateWithOptions(context.Background(), &model.CreateArticleRequest{
+		Status: "DRAFT",
+	}, "", "", CreateOptions{
+		ActorUserID:    "user-1",
+		IdempotencyKey: strings.Repeat("k", maxIdempotencyKeyLength+1),
+	})
+
+	if !errors.Is(err, constant.ErrBadRequest) {
+		t.Fatalf("CreateWithOptions() error = %v, want ErrBadRequest", err)
+	}
+	if txManager.callCount() != 0 {
+		t.Fatalf("transaction calls = %d, want 0", txManager.callCount())
+	}
+}
+
+func TestCreateWithOptionsRejectsBlankIdempotencyKey(t *testing.T) {
+	svc, _, txManager := newIdempotencyArticleService(t)
+	_, err := svc.CreateWithOptions(context.Background(), &model.CreateArticleRequest{
+		Status: "DRAFT",
+	}, "", "", CreateOptions{
+		ActorUserID:           "user-1",
+		IdempotencyKey:        " \t ",
+		IdempotencyKeyPresent: true,
+	})
+
+	if !errors.Is(err, constant.ErrBadRequest) {
+		t.Fatalf("CreateWithOptions() error = %v, want ErrBadRequest", err)
+	}
+	if txManager.callCount() != 0 {
+		t.Fatalf("transaction calls = %d, want 0", txManager.callCount())
+	}
+}
+
+func TestCreateWithOptionsRecoversConcurrentUniqueConflictAfterTransaction(t *testing.T) {
+	svc, repo, txManager := newIdempotencyArticleService(t)
+	repo.forceConcurrentPreflight = true
+	repo.preflightBarrier = make(chan struct{})
+	options := CreateOptions{ActorUserID: "user-1", IdempotencyKey: "concurrent-key"}
+
+	type result struct {
+		article *model.ArticleResponse
+		err     error
+	}
+	results := make(chan result, 2)
+	for range 2 {
+		go func() {
+			article, err := svc.CreateWithOptions(context.Background(), &model.CreateArticleRequest{
+				ContentMd: "same body",
+				Status:    "DRAFT",
+			}, "", "", options)
+			results <- result{article: article, err: err}
+		}()
+	}
+
+	first := <-results
+	second := <-results
+	if first.err != nil || second.err != nil {
+		t.Fatalf("concurrent errors = (%v, %v), want nil", first.err, second.err)
+	}
+	if first.article == nil || second.article == nil || first.article.ID != second.article.ID {
+		t.Fatalf("concurrent articles = (%v, %v), want the same article", first.article, second.article)
+	}
+	if txManager.callCount() != 2 {
+		t.Fatalf("transaction calls = %d, want 2 to exercise unique-conflict recovery", txManager.callCount())
+	}
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	if len(repo.byKey) != 1 {
+		t.Fatalf("committed idempotency records = %d, want 1", len(repo.byKey))
+	}
+}
+
+func TestCreateWithOptionsReplaysScheduledRequestAfterScheduledTimePassed(t *testing.T) {
+	svc, repo, txManager := newIdempotencyArticleService(t)
+	options := CreateOptions{ActorUserID: "user-1", IdempotencyKey: "scheduled-key"}
+	scheduledText := time.Now().Add(-time.Hour).Format(time.RFC3339Nano)
+	request := func() *model.CreateArticleRequest {
+		value := scheduledText
+		return &model.CreateArticleRequest{
+			Title:       "Scheduled article",
+			Status:      "DRAFT",
+			ScheduledAt: &value,
+		}
+	}
+
+	normalized := request()
+	if _, err := normalizeCreateArticlePayload(normalized); err != nil {
+		t.Fatalf("normalizeCreateArticlePayload() error = %v", err)
+	}
+	key, digest, err := prepareCreateIdempotency(normalized, options)
+	if err != nil {
+		t.Fatalf("prepareCreateIdempotency() error = %v", err)
+	}
+	repo.byKey[key] = idempotencyArticleRecord{
+		article: &model.Article{
+			ID:     "existing-scheduled-article",
+			Title:  "Scheduled article",
+			Status: "SCHEDULED",
+		},
+		digest: digest,
+	}
+
+	replayed, err := svc.CreateWithOptions(context.Background(), request(), "", "", options)
+	if err != nil {
+		t.Fatalf("replayed CreateWithOptions() error = %v", err)
+	}
+
+	if replayed.ID != "existing-scheduled-article" {
+		t.Fatalf("replayed ID = %q, want %q", replayed.ID, "existing-scheduled-article")
+	}
+	if txManager.callCount() != 0 {
+		t.Fatalf("transaction calls = %d, want 0", txManager.callCount())
+	}
+}

--- a/pkg/service/article/service.go
+++ b/pkg/service/article/service.go
@@ -996,9 +996,31 @@ func (s *serviceImpl) GetBySlugOrIDForPreview(ctx context.Context, slugOrID stri
 	return detailResponse, nil
 }
 
+func requiresArticleTitle(status string) bool {
+	switch status {
+	case "PUBLISHED", "SCHEDULED":
+		return true
+	default:
+		return false
+	}
+}
+
 // Create 处理创建新文章的完整业务流程。
 // referer 参数用于 NSUUU API 白名单验证
 func (s *serviceImpl) Create(ctx context.Context, req *model.CreateArticleRequest, ip, referer string) (*model.ArticleResponse, error) {
+
+	title := strings.TrimSpace(req.Title)
+	status := req.Status
+	if status == "" {
+		status = "DRAFT"
+		req.Status = status
+	}
+
+	if requiresArticleTitle(status) && title == "" {
+		return nil, errors.New("发布文章必须填写标题")
+	}
+
+	req.Title = title
 	// 验证 abbrlink（在事务外进行，避免不必要的事务开销）
 	if err := s.validateAbbrlink(ctx, req.Abbrlink, 0); err != nil {
 		return nil, err
@@ -1328,6 +1350,23 @@ func (s *serviceImpl) Update(ctx context.Context, publicID string, req *model.Up
 			return err
 		}
 		oldStatus = oldArticle.Status
+
+		// 拿到 oldArticle 后，算更新后的最终标题和更新后的最终状态
+		finalTitle := strings.TrimSpace(oldArticle.Title)
+		if req.Title != nil {
+			finalTitle = strings.TrimSpace(*req.Title)
+			req.Title = &finalTitle
+		}
+
+		finalStatus := oldArticle.Status
+		if req.Status != nil {
+			finalStatus = *req.Status
+		}
+
+		if requiresArticleTitle(finalStatus) && finalTitle == "" {
+			return errors.New("发布文章必须填写标题")
+		}
+
 		oldTagIDs := make([]uint, len(oldArticle.PostTags))
 		for i, t := range oldArticle.PostTags {
 			oldTagIDs[i], _, _ = idgen.DecodePublicID(t.ID)

--- a/pkg/service/article/service.go
+++ b/pkg/service/article/service.go
@@ -3,6 +3,8 @@ package article
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -42,6 +44,8 @@ type BatchDeleteResult struct {
 
 const defaultMaxArticleSummaries = 1
 
+const maxIdempotencyKeyLength = 200
+
 func normalizeArticleSummaries(raw []string, maxSummaries int, action string) []string {
 	if maxSummaries <= 0 {
 		maxSummaries = defaultMaxArticleSummaries
@@ -66,6 +70,7 @@ type Service interface {
 	// UploadArticleImageWithGroup 上传文章图片，并检查用户组权限
 	UploadArticleImageWithGroup(ctx context.Context, ownerID, userGroupID uint, fileReader io.Reader, originalFilename string) (fileURL string, publicFileID string, err error)
 	Create(ctx context.Context, req *model.CreateArticleRequest, ip, referer string) (*model.ArticleResponse, error)
+	CreateWithOptions(ctx context.Context, req *model.CreateArticleRequest, ip, referer string, options CreateOptions) (*model.ArticleResponse, error)
 	Get(ctx context.Context, publicID string) (*model.ArticleResponse, error)
 	Update(ctx context.Context, publicID string, req *model.UpdateArticleRequest, ip, referer string) (*model.ArticleResponse, error)
 	Delete(ctx context.Context, publicID string) error
@@ -101,6 +106,13 @@ type Service interface {
 
 	// GetArticleStatistics 获取文章统计数据（用于前台展示）
 	GetArticleStatistics(ctx context.Context) (*model.ArticleStatistics, error)
+}
+
+// CreateOptions 是创建文章时由可信调用方注入的内部选项，不属于请求体。
+type CreateOptions struct {
+	ActorUserID           string
+	IdempotencyKey        string
+	IdempotencyKeyPresent bool
 }
 
 // UploadArticleImageOptions 控制文章图片上传响应 URL 的可选行为。
@@ -1005,22 +1017,123 @@ func requiresArticleTitle(status string) bool {
 	}
 }
 
+func normalizeCreateArticlePayload(req *model.CreateArticleRequest) (*time.Time, error) {
+	req.Title = strings.TrimSpace(req.Title)
+	if req.Status == "" {
+		req.Status = "DRAFT"
+	}
+
+	var scheduledAt *time.Time
+	if req.ScheduledAt != nil && *req.ScheduledAt != "" {
+		parsedTime, err := time.Parse(time.RFC3339, *req.ScheduledAt)
+		if err != nil {
+			return nil, fmt.Errorf("%w: 无效的定时发布时间格式", constant.ErrBadRequest)
+		}
+		normalizedTime := parsedTime.UTC()
+		normalizedTimeText := normalizedTime.Format(time.RFC3339Nano)
+		req.ScheduledAt = &normalizedTimeText
+		scheduledAt = &normalizedTime
+		req.Status = "SCHEDULED"
+	}
+
+	req.Summaries = normalizeArticleSummaries(req.Summaries, req.MaxSummaries, "Create")
+	return scheduledAt, nil
+}
+
+func validateCreateArticleState(req *model.CreateArticleRequest, scheduledAt *time.Time, now time.Time) error {
+	if scheduledAt != nil && !scheduledAt.After(now) {
+		return fmt.Errorf("%w: 定时发布时间必须是未来时间", constant.ErrBadRequest)
+	}
+	if requiresArticleTitle(req.Status) && req.Title == "" {
+		return fmt.Errorf("%w: 发布或定时文章必须填写标题", constant.ErrBadRequest)
+	}
+	return nil
+}
+
+func prepareCreateIdempotency(
+	req *model.CreateArticleRequest,
+	options CreateOptions,
+) (string, string, error) {
+	keyProvided := options.IdempotencyKeyPresent || options.IdempotencyKey != ""
+	if !keyProvided {
+		return "", "", nil
+	}
+	if strings.TrimSpace(options.IdempotencyKey) == "" {
+		return "", "", fmt.Errorf("%w: Idempotency-Key 不能为空", constant.ErrBadRequest)
+	}
+	if len(options.IdempotencyKey) > maxIdempotencyKeyLength {
+		return "", "", fmt.Errorf(
+			"%w: Idempotency-Key 长度不能超过 %d 字节",
+			constant.ErrBadRequest,
+			maxIdempotencyKeyLength,
+		)
+	}
+	if strings.TrimSpace(options.ActorUserID) == "" {
+		return "", "", fmt.Errorf("%w: Idempotency-Key 缺少认证用户作用域", constant.ErrBadRequest)
+	}
+
+	keyHash := sha256.Sum256([]byte(options.ActorUserID + "\x00" + options.IdempotencyKey))
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return "", "", fmt.Errorf("序列化文章创建请求失败: %w", err)
+	}
+	requestHash := sha256.Sum256(payload)
+	return fmt.Sprintf("%x", keyHash), fmt.Sprintf("%x", requestHash), nil
+}
+
+func (s *serviceImpl) replayCreateByIdempotencyKey(
+	ctx context.Context,
+	keyHash, requestDigest string,
+) (*model.ArticleResponse, bool, error) {
+	if keyHash == "" {
+		return nil, false, nil
+	}
+	existing, existingDigest, err := s.repo.FindByCreateIdempotencyKey(ctx, keyHash)
+	if err != nil {
+		return nil, false, err
+	}
+	if existing == nil {
+		return nil, false, nil
+	}
+	if existingDigest != requestDigest {
+		return nil, true, fmt.Errorf("%w: Idempotency-Key 已用于不同的创建请求", constant.ErrConflict)
+	}
+
+	resp := s.ToAPIResponse(existing, false, true)
+	s.fillOwnerNickname(ctx, resp, nil)
+	return resp, true, nil
+}
+
 // Create 处理创建新文章的完整业务流程。
 // referer 参数用于 NSUUU API 白名单验证
 func (s *serviceImpl) Create(ctx context.Context, req *model.CreateArticleRequest, ip, referer string) (*model.ArticleResponse, error) {
+	return s.CreateWithOptions(ctx, req, ip, referer, CreateOptions{})
+}
 
-	title := strings.TrimSpace(req.Title)
-	status := req.Status
-	if status == "" {
-		status = "DRAFT"
-		req.Status = status
+// CreateWithOptions 处理创建文章，并支持按认证用户隔离的可选幂等创建。
+func (s *serviceImpl) CreateWithOptions(
+	ctx context.Context,
+	req *model.CreateArticleRequest,
+	ip, referer string,
+	options CreateOptions,
+) (*model.ArticleResponse, error) {
+	scheduledAt, err := normalizeCreateArticlePayload(req)
+	if err != nil {
+		return nil, err
+	}
+	idempotencyKey, requestDigest, err := prepareCreateIdempotency(req, options)
+	if err != nil {
+		return nil, err
+	}
+	if replay, found, err := s.replayCreateByIdempotencyKey(ctx, idempotencyKey, requestDigest); err != nil {
+		return nil, err
+	} else if found {
+		return replay, nil
+	}
+	if err := validateCreateArticleState(req, scheduledAt, time.Now()); err != nil {
+		return nil, err
 	}
 
-	if requiresArticleTitle(status) && title == "" {
-		return nil, errors.New("发布文章必须填写标题")
-	}
-
-	req.Title = title
 	// 验证 abbrlink（在事务外进行，避免不必要的事务开销）
 	if err := s.validateAbbrlink(ctx, req.Abbrlink, 0); err != nil {
 		return nil, err
@@ -1029,7 +1142,7 @@ func (s *serviceImpl) Create(ctx context.Context, req *model.CreateArticleReques
 	var newArticle *model.Article
 	sanitizedHTML := s.parserSvc.SanitizeHTML(req.ContentHTML)
 
-	err := s.txManager.Do(ctx, func(repos repository.Repositories) error {
+	err = s.txManager.Do(ctx, func(repos repository.Repositories) error {
 		wordCount, readingTime := calculatePostStats(req.ContentMd)
 
 		var ipLocation string
@@ -1106,9 +1219,6 @@ func (s *serviceImpl) Create(ctx context.Context, req *model.CreateArticleReques
 			showOnHome = *req.ShowOnHome
 		}
 
-		// 社区版默认最多 1 条；PRO 内部调用可显式提高上限。
-		filteredSummaries := normalizeArticleSummaries(req.Summaries, req.MaxSummaries, "Create")
-
 		// 解析自定义发布时间
 		log.Printf("[Service.Create] ========== 解析自定义时间 ==========")
 		log.Printf("[Service.Create] CustomPublishedAt 指针: %v", req.CustomPublishedAt)
@@ -1150,31 +1260,10 @@ func (s *serviceImpl) Create(ctx context.Context, req *model.CreateArticleReques
 		log.Printf("[Service.Create] 最终传递给Repository的 CustomPublishedAt: %v", customPublishedAt)
 		log.Printf("[Service.Create] 最终传递给Repository的 CustomUpdatedAt: %v", customUpdatedAt)
 
-		// 解析定时发布时间
-		var scheduledAt *time.Time
-		if req.ScheduledAt != nil && *req.ScheduledAt != "" {
-			log.Printf("[Service.Create] 开始解析定时发布时间: %s", *req.ScheduledAt)
-			if parsedTime, parseErr := time.Parse(time.RFC3339, *req.ScheduledAt); parseErr == nil {
-				// 验证定时发布时间必须是未来时间
-				if parsedTime.Before(time.Now()) {
-					return fmt.Errorf("定时发布时间必须是未来时间")
-				}
-				scheduledAt = &parsedTime
-				log.Printf("[Service.Create] ✅ 解析定时发布时间成功: %v", parsedTime)
-			} else {
-				log.Printf("[Service.Create] ❌ 解析定时发布时间失败: %v", parseErr)
-				return fmt.Errorf("无效的定时发布时间格式")
-			}
-		}
-
-		// 如果设置了定时发布时间，状态必须是 SCHEDULED
-		if scheduledAt != nil && req.Status != "SCHEDULED" {
-			log.Printf("[Service.Create] 检测到定时发布时间但状态不是 SCHEDULED，自动修正状态")
-			req.Status = "SCHEDULED"
-		}
-
 		params := &model.CreateArticleParams{
 			Title:                req.Title,
+			CreateIdempotencyKey: idempotencyKey,
+			CreateRequestDigest:  requestDigest,
 			OwnerID:              req.OwnerID,   // 文章作者ID（多人共创功能）
 			ContentMd:            req.ContentMd, // 存储Markdown原文
 			ContentHTML:          sanitizedHTML, // 存储安全过滤后的HTML
@@ -1188,7 +1277,7 @@ func (s *serviceImpl) Create(ctx context.Context, req *model.CreateArticleReques
 			HomeSort:             req.HomeSort,
 			PinSort:              req.PinSort,
 			TopImgURL:            req.TopImgURL,
-			Summaries:            filteredSummaries,
+			Summaries:            req.Summaries,
 			PrimaryColor:         primaryColor,
 			IsPrimaryColorManual: isManual,
 			ShowOnHome:           showOnHome,
@@ -1237,6 +1326,16 @@ func (s *serviceImpl) Create(ctx context.Context, req *model.CreateArticleReques
 		return nil
 	})
 	if err != nil {
+		if idempotencyKey != "" && errors.Is(err, constant.ErrConflict) {
+			if replay, found, replayErr := s.replayCreateByIdempotencyKey(ctx, idempotencyKey, requestDigest); replayErr != nil {
+				if found {
+					return nil, replayErr
+				}
+				log.Printf("[Create] 幂等冲突回查失败，保留原约束错误: %v", replayErr)
+			} else if found {
+				return replay, nil
+			}
+		}
 		return nil, err
 	}
 
@@ -1248,11 +1347,13 @@ func (s *serviceImpl) Create(ctx context.Context, req *model.CreateArticleReques
 	go s.invalidateRelatedCaches(context.Background())
 
 	// 异步更新搜索索引
-	go func() {
-		if err := s.searchSvc.IndexArticle(context.Background(), newArticle); err != nil {
-			log.Printf("[警告] 更新搜索索引失败: %v", err)
-		}
-	}()
+	if s.searchSvc != nil {
+		go func() {
+			if err := s.searchSvc.IndexArticle(context.Background(), newArticle); err != nil {
+				log.Printf("[警告] 更新搜索索引失败: %v", err)
+			}
+		}()
+	}
 
 	// 如果文章发布成功，触发订阅通知
 	if newArticle.Status == "PUBLISHED" {
@@ -1350,22 +1451,6 @@ func (s *serviceImpl) Update(ctx context.Context, publicID string, req *model.Up
 			return err
 		}
 		oldStatus = oldArticle.Status
-
-		// 拿到 oldArticle 后，算更新后的最终标题和更新后的最终状态
-		finalTitle := strings.TrimSpace(oldArticle.Title)
-		if req.Title != nil {
-			finalTitle = strings.TrimSpace(*req.Title)
-			req.Title = &finalTitle
-		}
-
-		finalStatus := oldArticle.Status
-		if req.Status != nil {
-			finalStatus = *req.Status
-		}
-
-		if requiresArticleTitle(finalStatus) && finalTitle == "" {
-			return errors.New("发布文章必须填写标题")
-		}
 
 		oldTagIDs := make([]uint, len(oldArticle.PostTags))
 		for i, t := range oldArticle.PostTags {
@@ -1487,11 +1572,11 @@ func (s *serviceImpl) Update(ctx context.Context, publicID string, req *model.Up
 		if req.ScheduledAt != nil && *req.ScheduledAt != "" {
 			scheduledTime, parseErr := time.Parse(time.RFC3339, *req.ScheduledAt)
 			if parseErr != nil {
-				return fmt.Errorf("无效的定时发布时间格式: %w", parseErr)
+				return fmt.Errorf("%w: 无效的定时发布时间格式", constant.ErrBadRequest)
 			}
 			// 验证定时发布时间必须是未来时间
-			if scheduledTime.Before(time.Now()) {
-				return fmt.Errorf("定时发布时间必须是未来时间")
+			if !scheduledTime.After(time.Now()) {
+				return fmt.Errorf("%w: 定时发布时间必须是未来时间", constant.ErrBadRequest)
 			}
 			// 如果设置了定时发布时间，状态必须是 SCHEDULED
 			if req.Status == nil || *req.Status != "SCHEDULED" {
@@ -1506,6 +1591,21 @@ func (s *serviceImpl) Update(ctx context.Context, publicID string, req *model.Up
 			emptyScheduledAt := ""
 			req.ScheduledAt = &emptyScheduledAt
 			log.Printf("[更新文章] 状态从 SCHEDULED 变更为 %s，清除定时发布时间", *req.Status)
+		}
+
+		// 定时状态归一化完成后再校验最终状态。
+		// 未提供的字段保持 partial update 语义；仓储会用原子 WHERE 守卫危险组合。
+		finalTitle := strings.TrimSpace(oldArticle.Title)
+		if req.Title != nil {
+			finalTitle = strings.TrimSpace(*req.Title)
+			req.Title = &finalTitle
+		}
+		finalStatus := oldArticle.Status
+		if req.Status != nil {
+			finalStatus = *req.Status
+		}
+		if requiresArticleTitle(finalStatus) && finalTitle == "" {
+			return fmt.Errorf("%w: 发布或定时文章必须填写标题", constant.ErrBadRequest)
 		}
 
 		articleAfterUpdate, err := repos.Article.Update(ctx, publicID, req, &computedParams)


### PR DESCRIPTION
## 变更摘要 / Summary

- 允许草稿在标题为空时创建和保存；发布、定时发布仍强制要求标题。
- 创建接口支持按登录用户隔离的 `Idempotency-Key`，同请求重试返回同一文章，请求体冲突返回 409。
- 更新与定时发布通过仓储 CAS 守住“公开文章必须有标题”的不变量，避免并发部分更新产生非法状态。
- 补齐 400 / 404 / 409 错误映射、CORS 头、Swagger 契约、Ent schema 与生成代码。
- 将 `frontend` 子模块更新到已合并的前端自动保存与 `!!! note` 编辑器支持版本。

审核中还修复了真实缺失文章误报 500、软删除幂等回放、事务并发冲突回读，以及 PATCH 旧字段写回问题。

## 验证方式 / Verification

- `go test ./...`
- `go test -race ./internal/app/middleware ./internal/infra/persistence/ent ./pkg/handler/article ./pkg/service/article`
- `go vet ./...`
- `go build ./...`
- `go mod verify`
- `go generate ./ent` 生成前后无差异
- Swagger 重新生成后与仓库产物无差异
- `git diff --check`

## 关联 Issue / Related Issue

关联 #270（前端修复已随 PR #10 合并，Issue 已关闭）。

## 提交前检查项 / Checklist

- [x] 我已确认该 PR 不是重复提交。
- [x] 我已按项目现有风格完成改动。
- [x] 我已运行必要的测试或说明无法运行的原因。
- [x] 我已人工检查 PR 内容，没有直接粘贴未经验证的 AI 输出。