### PR TITLE
Change Only() to First() in article_repo.go

### DIFF
--- a/internal/infra/persistence/ent/article_repo.go
+++ b/internal/infra/persistence/ent/article_repo.go
@@ -1052,7 +1052,7 @@ func (r *articleRepo) GetRandom(ctx context.Context) (*model.Article, error) {
 		Limit(1).
 		WithPostTags().
 		WithPostCategories().
-		Only(ctx)
+		First(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return nil, constant.ErrNotFound


### PR DESCRIPTION
第 1055 行，函数 GetRandom 里，把 .Only(ctx) 改成 .First(ctx)。解决随机文章/api/public/articles/random 500报错。


