### PR TITLE
Update article_repo.go

### DIFF
--- a/internal/infra/persistence/ent/article_repo.go
+++ b/internal/infra/persistence/ent/article_repo.go
@@ -1052,7 +1052,7 @@ func (r *articleRepo) GetRandom(ctx context.Context) (*model.Article, error) {
 		Limit(1).
 		WithPostTags().
 		WithPostCategories().
-		Only(ctx)
+		First(ctx)
 	if err != nil {
 		if ent.IsNotFound(err) {
 			return nil, constant.ErrNotFound


### PR DESCRIPTION
## 变更摘要 / Summary

修复 `/api/public/articles/random` 接口在站点有 2 篇及以上已发布文章时必定返回 500 的问题。

根因：`internal/infra/persistence/ent/article_repo.go` 的 `GetRandom` 方法使用 `.Only(ctx)` 获取随机文章。ent 的 `Only()` 内部执行 `LIMIT 2` 并要求结果恰好 1 行，否则抛 `NotSingularError`。当满足条件（status=PUBLISHED、未删除、未下架）的文章 ≥ 2 篇时，每次调用都会命中 "ent: article not singular" 而返回 500；只有恰好 1 篇时才碰巧成功（这也是该问题在文章较少的测试环境下未被暴露的原因）。

改动：将 `.Only(ctx)` 改为 `.First(ctx)`，取排序后的第一行，不再对结果行数做 singular 校验。仅一处一行改动，不影响随机逻辑。

## 验证方式 / Verification

- 本地阅读 `ent/article_query.go` 中 `Only()` 实现，确认其内部为 `Limit(2).All()` + singular 校验，验证根因成立。
- 在含 386 篇已发布文章的实际站点上复现 500（`{"code":500,"message":"获取随机文章失败: ent: article not singular"}`）。
- 改为 `.First(ctx)` 后，`/api/public/articles/random` 正常返回随机文章，不再报错。

## 关联 Issue / Related Issue

无关联 issue。此问题为线上实际部署中发现：任何拥有 ≥2 篇已发布文章的站点调用随机文章接口都会稳定 500，故直接提交修复。

## 提交前检查项 / Checklist

- [x] 我已确认该 PR 不是重复提交。
- [x] 我已按项目现有风格完成改动。
- [x] 我已运行必要的测试或说明无法运行的原因。
- [x] 我已人工检查 PR 内容，没有直接粘贴未经验证的 AI 输出。
